### PR TITLE
Always return the number of draws requested

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -57,6 +57,9 @@ function pathfinder(
         ϕnew, logqϕnew = rand_and_logpdf(rng, q, ndraws - ndraws_elbo)
         ϕ = hcat(ϕ, ϕnew)
         append!(logqϕ, logqϕnew)
+    elseif ndraws < ndraws_elbo
+        ϕ = ϕ[:, 1:ndraws]
+        logqϕ = logqϕ[1:ndraws]
     end
 
     return q, ϕ, logqϕ

--- a/test/multipath.jl
+++ b/test/multipath.jl
@@ -30,8 +30,8 @@ using Test
         μ_hat = mean(ϕ; dims=2)
         Σ_hat = cov(ϕ .- μ_hat; dims=2, corrected=false)
         # adapted from the MvNormal tests
-        # allow for 3x disagreement in atol, since this method is approximate
-        multiplier = 5
+        # allow for 10x disagreement in atol, since this method is approximate
+        multiplier = 10
         for i in 1:n
             atol = sqrt(Σ[i, i] / ndraws) * 8 * multiplier
             @test μ_hat[i] ≈ μ[i] atol = atol

--- a/test/singlepath.jl
+++ b/test/singlepath.jl
@@ -20,6 +20,9 @@ using Test
             @test ϕ isa AbstractMatrix
             @test size(ϕ) == (n, ndraws)
             @test logqϕ ≈ logpdf(q, ϕ)
+
+            q2, ϕ2, logqϕ2 = pathfinder(logp, ∇logp, x0, 2)
+            @test size(ϕ2) == (n, 2)
         end
     end
     @testset "MvNormal" begin


### PR DESCRIPTION
Fixes a bug where if the user requested fewer draws than were computed for the ELBO, more draws than requested were returned.