### PR TITLE
Increase history length to 6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -16,7 +16,9 @@ export pathfinder, multipathfinder
 # to be More-Thuente, which keeps the approximate inverse Hessian positive-definite
 const DEFAULT_HISTORY_LENGTH = 6
 const DEFAULT_LINE_SEARCH = LineSearches.MoreThuente()
-const DEFAULT_OPTIMIZER = Optim.LBFGS(; m=DEFAULT_HISTORY_LENGTH, linesearch=DEFAULT_LINE_SEARCH)
+const DEFAULT_OPTIMIZER = Optim.LBFGS(;
+    m=DEFAULT_HISTORY_LENGTH, linesearch=DEFAULT_LINE_SEARCH
+)
 
 include("woodbury.jl")
 include("maximize.jl")

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -14,7 +14,9 @@ export pathfinder, multipathfinder
 
 # Note: we override the default history length to be shorter and the default line search
 # to be More-Thuente, which keeps the approximate inverse Hessian positive-definite
-const DEFAULT_OPTIMIZER = Optim.LBFGS(; m=5, linesearch=LineSearches.MoreThuente())
+const DEFAULT_HISTORY_LENGTH = 6
+const DEFAULT_LINE_SEARCH = LineSearches.MoreThuente()
+const DEFAULT_OPTIMIZER = Optim.LBFGS(; m=DEFAULT_HISTORY_LENGTH, linesearch=DEFAULT_LINE_SEARCH)
 
 include("woodbury.jl")
 include("maximize.jl")

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -15,9 +15,9 @@ bound (ELBO), or equivalently, minimizes the KL divergence between
 # Keywords
 - `rng::Random.AbstractRNG`: The random number generator to be used for drawing samples
 - `optimizer::Optim.AbstractOptimizer`: Optimizer to be used for constructing trajectory.
-Defaults to `Optim.LBFGS(; m=5, linesearch=LineSearches.MoreThuente())`.
-- `history_length::Int=5`: Size of the history used to approximate the inverse Hessian.
-This should only be set when `optimizer` is not an `Optim.LBFGS`.
+Defaults to `Optim.LBFGS(; m=$DEFAULT_HISTORY_LENGTH, linesearch=$DEFAULT_LINE_SEARCH)`.
+- `history_length::Int=$DEFAULT_HISTORY_LENGTH`: Size of the history used to approximate the
+inverse Hessian. This should only be set when `optimizer` is not an `Optim.LBFGS`.
 - `ndraws_elbo::Int=5`: Number of draws used to estimate the ELBO
 - `kwargs...` : Remaining keywords are forwarded to `Optim.Options`.
 
@@ -33,7 +33,7 @@ function pathfinder(
     ndraws;
     rng::Random.AbstractRNG=Random.default_rng(),
     optimizer::Optim.AbstractOptimizer=DEFAULT_OPTIMIZER,
-    history_length::Int=optimizer isa Optim.LBFGS ? optimizer.m : 5,
+    history_length::Int=optimizer isa Optim.LBFGS ? optimizer.m : DEFAULT_HISTORY_LENGTH,
     ndraws_elbo::Int=5,
     kwargs...,
 )


### PR DESCRIPTION
Adopts the Pathfinder paper's default history length of 6 instead of 5.