### PR TITLE
Dont terminate on NaN

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.3.0-DEV"
+version = "0.3.0"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -48,8 +48,6 @@ function optimize_with_trace(prob, optimizer)
         # so we need to recompute it ourselves
         # see https://github.com/SciML/GalacticOptim.jl/issues/149
         ∇fx = ∇f(x)
-        # terminate if optimization encounters NaNs
-        (isnan(nfx) || any(isnan, x) || any(isnan, ∇fx)) && return true
         # some backends mutate x, so we must copy it
         push!(xs, copy(x))
         push!(fxs, -nfx)

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -39,21 +39,19 @@ function optimize_with_trace(prob, optimizer)
         rmul!(∇fx, -1)
         return ∇fx
     end
-    # caches for the trace of x, f(x), and ∇f(x)
+    # caches for the trace of x and f(x)
     xs = typeof(u0)[]
     fxs = typeof(fun.f(u0, nothing))[]
-    ∇fxs = typeof(similar(u0))[]
     function callback(x, nfx, args...)
-        # NOTE: GalacticOptim doesn't have an interface for accessing the gradient trace,
-        # so we need to recompute it ourselves
-        # see https://github.com/SciML/GalacticOptim.jl/issues/149
-        ∇fx = ∇f(x)
         # some backends mutate x, so we must copy it
         push!(xs, copy(x))
         push!(fxs, -nfx)
-        push!(∇fxs, ∇fx)
         return false
     end
     GalacticOptim.solve(prob, optimizer; cb=callback)
+    # NOTE: GalacticOptim doesn't have an interface for accessing the gradient trace,
+    # so we need to recompute it ourselves
+    # see https://github.com/SciML/GalacticOptim.jl/issues/149
+    ∇fxs = ∇f.(xs)
     return xs, fxs, ∇fxs
 end


### PR DESCRIPTION
As pointed out in https://github.com/sethaxen/Pathfinder.jl/pull/25#discussion_r797772849, some solvers can recover from NaNs, so we shouldn't just terminate. It's unclear how best to work around traces that contain some NaN points/gradients without an example, and we can handle that when we have one.