### PR TITLE
Make mu generation type-inferrable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/mvnormal.jl
+++ b/src/mvnormal.jl
@@ -11,7 +11,7 @@ point are returned.
 function fit_mvnormals(θs, ∇logpθs; kwargs...)
     Σs = lbfgs_inverse_hessians(θs, ∇logpθs; kwargs...)
     l = length(Σs)
-    μs = @views muladd.(Σs, ∇logpθs[1:l], θs[1:l])
+    μs = @views map(muladd, Σs, ∇logpθs[1:l], θs[1:l])
     return Distributions.MvNormal.(μs, Σs)
 end
 


### PR DESCRIPTION
Use `map` instead of `broadcast` for type-stability. For some reason, this was never a problem in the CI and only when executing via the REPL.