### PR TITLE
Improve stability of quad test

### DIFF
--- a/test/woodbury.jl
+++ b/test/woodbury.jl
@@ -154,13 +154,13 @@ end
             @test @inferred(quad(W, x)) ≈ dot(x, Wmat, x)
 
             u = randn(T, n)
-            @test quad(W, unwhiten(inv(W), u)) ≈ dot(u, u)
+            @test quad(W, Pathfinder.invunwhiten!(similar(u), W, u)) ≈ dot(u, u)
 
             X = randn(T, n, 100)
             @test @inferred(quad(W, X)) ≈ quad(PDMats.PDMat(Symmetric(Wmat)), X)
 
             U = randn(T, n, 100)
-            @test quad(W, unwhiten(inv(W), U)) ≈ vec(sum(abs2, U; dims=1))
+            @test quad(W, Pathfinder.invunwhiten!(similar(U), W, U)) ≈ vec(sum(abs2, U; dims=1))
         end
 
         @testset "PDMats.invquad" begin


### PR DESCRIPTION
The `quad` test is currently slightly numerically unstable for `Float32` (see https://github.com/sethaxen/Pathfinder.jl/runs/6063221968?check_suite_focus=true). I can't replicate this on my machine, but I assume it's due to `inv` being imprecise for numbers of low precision. This PR uses `invunwhiten!` instead.