### PR TITLE
Add AdvancedHMC compatibility

### DIFF
--- a/.github/workflows/IntegrationTests.yml
+++ b/.github/workflows/IntegrationTests.yml
@@ -1,7 +1,7 @@
 name: IntegrationTest
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: [v*]
   pull_request:
 jobs:

--- a/.github/workflows/IntegrationTests.yml
+++ b/.github/workflows/IntegrationTests.yml
@@ -16,6 +16,7 @@ jobs:
         arch: [x64]
         package:
           - DynamicHMC
+          - AdvancedHMC
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -38,6 +38,9 @@ function __init__()
     Requires.@require DynamicHMC = "bbc10e6e-7c05-544b-b16e-64fede858acb" begin
         include("integration/dynamichmc.jl")
     end
+    Requires.@require AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d" begin
+        include("integration/advancedhmc.jl")
+    end
 end
 
 end

--- a/src/integration/advancedhmc.jl
+++ b/src/integration/advancedhmc.jl
@@ -1,0 +1,79 @@
+using .AdvancedHMC: AdvancedHMC
+
+"""
+    RankUpdateEuclideanMetric{T,M} <: AdvancedHMC.AbstractMetric
+
+A Gaussian Euclidean metric whose inverse is constructed by rank-updates.
+
+# Constructors
+
+    RankUpdateEuclideanMetric(n::Int)
+    RankUpdateEuclideanMetric(M⁻¹::Pathfinder.WoodburyPDMat)
+
+Construct a Gaussian Euclidean metric of size `(n, n)` with inverse of `M⁻¹`.
+
+# Example
+
+```jldoctest
+julia> using LinearAlgebra, Pathfinder, AdvancedHMC
+
+julia> Pathfinder.RankUpdateEuclideanMetric(3)
+RankUpdateEuclideanMetric(diag=[1.0, 1.0, 1.0])
+
+julia> W = Pathfinder.WoodburyPDMat(Diagonal([0.1, 0.2]), [0.7 0.2]', Diagonal([0.3]))
+2×2 Pathfinder.WoodburyPDMat{Float64, Diagonal{Float64, Vector{Float64}}, Adjoint{Float64, Matrix{Float64}}, Diagonal{Float64, Vector{Float64}}, Diagonal{Float64, Vector{Float64}}, QRCompactWYQ{Float64, Matrix{Float64}, Matrix{Float64}}, UpperTriangular{Float64, Matrix{Float64}}}:
+ 0.247  0.042
+ 0.042  0.212
+
+julia> Pathfinder.RankUpdateEuclideanMetric(W)
+RankUpdateEuclideanMetric(diag=[0.247, 0.21200000000000002])
+```
+"""
+RankUpdateEuclideanMetric
+
+struct RankUpdateEuclideanMetric{T,M<:WoodburyPDMat{T,<:Diagonal{T}}} <:
+       AdvancedHMC.AbstractMetric
+    M⁻¹::M
+end
+
+function RankUpdateEuclideanMetric(n::Int)
+    M⁻¹ = WoodburyPDMat(Diagonal(ones(n)), zeros(n, 0), zeros(0, 0))
+    return RankUpdateEuclideanMetric(M⁻¹)
+end
+function RankUpdateEuclideanMetric(::Type{T}, D::Int) where {T}
+    return RankUpdateEuclideanMetric(
+        WoodburyPDMat(Diagonal(ones(T, D)), Matrix{T}(undef, D, 0), Matrix{T}(undef, 0, 0))
+    )
+end
+function RankUpdateEuclideanMetric(::Type{T}, sz::Tuple{Int}) where {T}
+    return RankUpdateEuclideanMetric(T, first(sz))
+end
+RankUpdateEuclideanMetric(sz::Tuple{Int}) = RankUpdateEuclideanMetric(Float64, sz)
+
+AdvancedHMC.renew(::RankUpdateEuclideanMetric, M⁻¹) = RankUpdateEuclideanMetric(M⁻¹)
+
+Base.size(metric::RankUpdateEuclideanMetric, dim...) = size(metric.M⁻¹, dim...)
+
+function Base.show(io::IO, metric::RankUpdateEuclideanMetric)
+    print(io, "RankUpdateEuclideanMetric(diag=$(diag(metric.M⁻¹)))")
+    return nothing
+end
+
+function Base.rand(rng::AbstractRNG, metric::RankUpdateEuclideanMetric{T}) where {T}
+    M⁻¹ = metric.M⁻¹
+    r = randn(rng, T, size(M⁻¹, 2)...)
+    invunwhiten!(r, M⁻¹, r)
+    return r
+end
+
+function AdvancedHMC.neg_energy(
+    h::AdvancedHMC.Hamiltonian{<:RankUpdateEuclideanMetric}, r::T, θ::T
+) where {T<:AbstractVecOrMat}
+    return -PDMats.quad(h.metric.M⁻¹, r) / 2
+end
+
+function AdvancedHMC.∂H∂r(
+    h::AdvancedHMC.Hamiltonian{<:RankUpdateEuclideanMetric}, r::AbstractVecOrMat
+)
+    return h.metric.M⁻¹ * r
+end

--- a/test/integration/AdvancedHMC/Project.toml
+++ b/test/integration/AdvancedHMC/Project.toml
@@ -1,0 +1,18 @@
+[deps]
+AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
+Pathfinder = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+AdvancedHMC = "0.3"
+Distributions = "0.25"
+Optim = "1.4"
+Pathfinder = "0.3"
+StatsBase = "0.33"
+julia = "1.6"

--- a/test/integration/AdvancedHMC/runtests.jl
+++ b/test/integration/AdvancedHMC/runtests.jl
@@ -1,0 +1,132 @@
+using AdvancedHMC,
+    Distributions, ForwardDiff, LinearAlgebra, Optim, Pathfinder, Random, StatsBase, Test
+
+struct RegressionModel{X,Y}
+    x::X
+    y::Y
+end
+
+function (m::RegressionModel)(θ)
+    logσ = θ[1]
+    σ = exp(logσ)
+    α = θ[2]
+    β = θ[3:end]
+    x = m.x
+    y = m.y
+    lp = logpdf(truncated(Normal(); lower=0), σ) + logσ
+    lp += logpdf(Normal(), α)
+    lp += sum(b -> logpdf(Normal(), b), β)
+    y_hat = muladd(x, β, α)
+    lp += sum(eachindex(y_hat, y)) do i
+        return loglikelihood(Normal(y_hat[i], σ), y[i])
+    end
+    return lp
+end
+
+@testset "AdvancedHMC integration" begin
+    A = Diagonal(rand(5))
+    B = randn(5, 2)
+    D = exp(Symmetric(randn(2, 2)))
+    M⁻¹ = Pathfinder.WoodburyPDMat(A, B, D)
+    A2 = Diagonal(rand(5))
+    B2 = randn(5, 2)
+    D2 = exp(Symmetric(randn(2, 2)))
+    M⁻¹2 = Pathfinder.WoodburyPDMat(A2, B2, D2)
+    ℓπ(x) = -sum(abs2, x) / 2
+    ∂ℓπ∂θ(x) = -x
+
+    @testset "RankUpdateEuclideanMetric" begin
+        metric = Pathfinder.RankUpdateEuclideanMetric(M⁻¹)
+        @test metric.M⁻¹ === M⁻¹
+        metric_dense = AdvancedHMC.DenseEuclideanMetric(Symmetric(Matrix(M⁻¹)))
+        h = AdvancedHMC.Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
+        h_dense = AdvancedHMC.Hamiltonian(metric_dense, ℓπ, ∂ℓπ∂θ)
+        r = randn(5)
+        θ = randn(5)
+
+        metric2 = Pathfinder.RankUpdateEuclideanMetric(3)
+        @test metric2.M⁻¹ ≈ I
+        @test size(metric2) == (3, 3)
+        metric2 = Pathfinder.RankUpdateEuclideanMetric((4,))
+        @test metric2.M⁻¹ ≈ I
+        @test size(metric2) == (4, 4)
+        metric2 = Pathfinder.RankUpdateEuclideanMetric(Float32, (4,))
+        @test metric2.M⁻¹ ≈ I
+        @test size(metric2) == (4, 4)
+        @test eltype(metric2.M⁻¹) === Float32
+
+        @test size(metric) == (5, 5)
+        @test AdvancedHMC.renew(metric, M⁻¹2).M⁻¹ === M⁻¹2
+        @test sprint(show, metric) == "RankUpdateEuclideanMetric(diag=$(diag(metric.M⁻¹)))"
+        @test AdvancedHMC.neg_energy(h, r, θ) ≈ AdvancedHMC.neg_energy(h_dense, r, θ)
+        @test AdvancedHMC.∂H∂r(h, r) ≈ AdvancedHMC.∂H∂r(h_dense, r)
+        m, v = mean_and_var([rand(metric) for _ in 1:10_000])
+        m_dense, v_dense = mean_and_var([rand(metric_dense) for _ in 1:10_000])
+        # NOTE: a more strict test would compute MCSE here
+        s = sqrt.(v .+ v_dense)
+        bounds = quantile.(Normal.(0, s), 0.05)
+        @test all(bounds .< m - m_dense .< -bounds)
+    end
+
+    @testset "sample" begin
+        ndraws = 1_000
+        nadapts = 500
+        nparams = 5
+        rng = MersenneTwister(42)
+        x = 0:0.01:1
+        y = sin.(x) .+ randn.(rng) .* 0.2 .+ x
+        X = [x x .^ 2 x .^ 3]
+        θ₀ = randn(rng, nparams)
+        ℓπ = RegressionModel(X, y)
+
+        metric = DiagEuclideanMetric(nparams)
+        hamiltonian = Hamiltonian(metric, ℓπ, ForwardDiff)
+        ϵ = find_good_stepsize(hamiltonian, θ₀)
+        integrator = Leapfrog(ϵ)
+        proposal = NUTS{MultinomialTS,GeneralisedNoUTurn}(integrator)
+        adaptor = StanHMCAdaptor(
+            MassMatrixAdaptor(metric), StepSizeAdaptor(0.8, integrator)
+        )
+        samples1, stats1 = sample(
+            rng,
+            hamiltonian,
+            proposal,
+            θ₀,
+            ndraws,
+            adaptor,
+            nadapts;
+            drop_warmup=true,
+            progress=false,
+        )
+
+        θ₀ = rand(rng, Uniform(-2, 2), nparams)
+        result_pf = pathfinder(ℓπ, θ₀, 1; rng, optimizer=Optim.LBFGS(; m=6))
+        θ₀ = result_pf[2][:, 1]
+        metric = Pathfinder.RankUpdateEuclideanMetric(result_pf[1].Σ)
+        hamiltonian = Hamiltonian(metric, ℓπ, ForwardDiff)
+        ϵ = find_good_stepsize(hamiltonian, θ₀)
+        integrator = Leapfrog(ϵ)
+        proposal = NUTS{MultinomialTS,GeneralisedNoUTurn}(integrator)
+        adaptor = StepSizeAdaptor(0.8, integrator)
+        samples2, stats2 = sample(
+            rng,
+            hamiltonian,
+            proposal,
+            θ₀,
+            ndraws,
+            adaptor,
+            nadapts;
+            drop_warmup=true,
+            progress=false,
+        )
+
+        # check that the posterior means are approximately equal
+        m1, v1 = mean_and_var(samples1)
+        m2, v2 = mean_and_var(samples2)
+        # NOTE: a more strict test would compute MCSE here
+        s = sqrt.(v1 .+ v2)
+        m = m1 - m2
+        bounds = quantile.(Normal.(0, s), 0.05)
+        @test all(bounds .< m .< -bounds)
+    end
+end


### PR DESCRIPTION
This PR adds compatibility with AdvancedHMC via a `RankUpdateEuclideanMetric` type that implements AdvancedHMC's metric API. For usage, see the tests.