### PR TITLE
Improve setting of PRNGs in tests (redux)

### DIFF
--- a/test/elbo.jl
+++ b/test/elbo.jl
@@ -10,7 +10,7 @@ using Transducers
         target_dist = Normal(0, σ_target)
         logp(x) = logpdf(target_dist, x[1])
         σs = [1e-3, 0.05, 0.8, 1.0, 1.1, 1.2, 5.0, 10.0]
-        rng = MersenneTwister(42)
+        rng = Random.seed!(Random.default_rng(), 42)
         @testset for σ in σs
             dist = Normal(0, σ)
             elbo, ϕ, logqϕ = @inferred Pathfinder.elbo_and_samples(
@@ -36,13 +36,13 @@ using Transducers
             executors = [SequentialEx()]
         end
         @testset "$executor" for executor in executors
-            rng = Random.seed!(42)
+            rng = Random.seed!(Random.default_rng(), 42)
             lopt, elbo, ϕ, logqϕ = @inferred Pathfinder.maximize_elbo(
                 rng, logp, dists, 100, executor
             )
             @test lopt == 3
             @test elbo ≈ 0
-            rng = Random.seed!(42)
+            rng = Random.seed!(Random.default_rng(), 42)
             lopt2, elbo2, ϕ2, logqϕ2 = Pathfinder.maximize_elbo(
                 rng, logp, dists, 100, executor
             )

--- a/test/integration/AdvancedHMC/runtests.jl
+++ b/test/integration/AdvancedHMC/runtests.jl
@@ -9,6 +9,8 @@ using AdvancedHMC,
     StatsFuns,
     Test
 
+Random.seed!(0)
+
 struct RegressionModel{X,Y}
     x::X
     y::Y
@@ -96,11 +98,10 @@ end
         ndraws = 1_000
         nadapts = 500
         nparams = 5
-        rng = MersenneTwister(42)
         x = 0:0.01:1
-        y = sin.(x) .+ randn.(rng) .* 0.2 .+ x
+        y = sin.(x) .+ randn.() .* 0.2 .+ x
         X = [x x .^ 2 x .^ 3]
-        θ₀ = randn(rng, nparams)
+        θ₀ = randn(nparams)
         ℓπ = RegressionModel(X, y)
 
         metric = DiagEuclideanMetric(nparams)
@@ -112,7 +113,6 @@ end
             MassMatrixAdaptor(metric), StepSizeAdaptor(0.8, integrator)
         )
         samples1, stats1 = sample(
-            rng,
             hamiltonian,
             proposal,
             θ₀,
@@ -123,8 +123,8 @@ end
             progress=false,
         )
 
-        θ₀ = rand(rng, nparams) .* 4 .- 2
-        result_pf = pathfinder(ℓπ, θ₀, 1; rng, optimizer=Optim.LBFGS(; m=6))
+        θ₀ = rand(nparams) .* 4 .- 2
+        result_pf = pathfinder(ℓπ, θ₀, 1; optimizer=Optim.LBFGS(; m=6))
 
         @testset "Initial point" begin
             metric = DiagEuclideanMetric(nparams)
@@ -134,7 +134,6 @@ end
             proposal = NUTS{MultinomialTS,GeneralisedNoUTurn}(integrator)
             adaptor = StepSizeAdaptor(0.8, integrator)
             samples2, stats2 = sample(
-                rng,
                 hamiltonian,
                 proposal,
                 result_pf[2][:, 1],
@@ -155,7 +154,6 @@ end
             proposal = NUTS{MultinomialTS,GeneralisedNoUTurn}(integrator)
             adaptor = StepSizeAdaptor(0.8, integrator)
             samples3, stats3 = sample(
-                rng,
                 hamiltonian,
                 proposal,
                 result_pf[2][:, 1],
@@ -176,7 +174,6 @@ end
             proposal = NUTS{MultinomialTS,GeneralisedNoUTurn}(integrator)
             adaptor = StepSizeAdaptor(0.8, integrator)
             samples4, stats4 = sample(
-                rng,
                 hamiltonian,
                 proposal,
                 result_pf[2][:, 1],

--- a/test/integration/DynamicHMC/runtests.jl
+++ b/test/integration/DynamicHMC/runtests.jl
@@ -10,7 +10,7 @@ using DynamicHMC,
     Test,
     TransformVariables
 
-Random.seed!(0)
+Random.seed!(1)
 
 struct RegressionProblem{X,Y}
     x::X

--- a/test/integration/DynamicHMC/runtests.jl
+++ b/test/integration/DynamicHMC/runtests.jl
@@ -10,6 +10,8 @@ using DynamicHMC,
     Test,
     TransformVariables
 
+Random.seed!(0)
+
 struct RegressionProblem{X,Y}
     x::X
     y::Y
@@ -90,21 +92,21 @@ end
 
     @testset "DynamicHMC.mcmc_with_warmup" begin
         ndraws = 1_000
-        rng = MersenneTwister(42)
         x = 0:0.01:1
-        y = sin.(x) .+ randn.(rng) .* 0.2 .+ x
+        y = sin.(x) .+ randn.() .* 0.2 .+ x
         X = [x x .^ 2 x .^ 3]
         prob = RegressionProblem(X, y)
         trans = as((σ=asℝ₊, α=asℝ, β=as(Array, size(X, 2))))
         P = TransformedLogDensity(trans, prob)
         ∇P = ADgradient(:ForwardDiff, P)
+        rng = Random.GLOBAL_RNG
 
         result_hmc1 = mcmc_with_warmup(rng, ∇P, ndraws; reporter=NoProgressReport())
 
         logp(x) = LogDensityProblems.logdensity(P, x)
         ∇logp(x) = LogDensityProblems.logdensity_and_gradient(∇P, x)[2]
-        θ₀ = rand(rng, LogDensityProblems.dimension(P)) .* 4 .- 2
-        result_pf = pathfinder(logp, ∇logp, θ₀, 1; rng)
+        θ₀ = rand(LogDensityProblems.dimension(P)) .* 4 .- 2
+        result_pf = pathfinder(logp, ∇logp, θ₀, 1)
 
         @testset "Initial point" begin
             result_hmc2 = mcmc_with_warmup(

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -34,9 +34,10 @@ include("test_utils.jl")
             μ = randn(n)
             dist = MvNormal(μ, Σ)
 
-            rng = MersenneTwister(42)
+            seed = 42
+            rng = Random.seed!(Random.default_rng(), seed)
             x, logpx = @inferred Pathfinder.rand_and_logpdf(rng, dist, ndraws)
-            rng = MersenneTwister(42)
+            Random.seed!(rng, seed)
             x2 = rand(rng, dist, ndraws)
             logpx2 = logpdf(dist, x2)
             @test x ≈ x2
@@ -54,9 +55,10 @@ include("test_utils.jl")
             μ = randn(n)
             dist = MvNormal(μ, Σ)
 
-            rng = MersenneTwister(42)
+            seed = 42
+            rng = Random.seed!(Random.default_rng(), seed)
             x, logpx = @inferred Pathfinder.rand_and_logpdf(rng, dist, ndraws)
-            rng = MersenneTwister(42)
+            Random.seed!(rng, seed)
             x2 = rand(rng, dist, ndraws)
             logpx2 = logpdf(dist, x2)
             @test x ≈ x2
@@ -68,9 +70,10 @@ include("test_utils.jl")
             μ = randn()
             dist = Normal(μ, σ)
 
-            rng = MersenneTwister(42)
+            seed = 42
+            rng = Random.seed!(Random.default_rng(), seed)
             x, logpx = @inferred Pathfinder.rand_and_logpdf(rng, dist, ndraws)
-            rng = MersenneTwister(42)
+            Random.seed!(rng, seed)
             x2 = rand(rng, dist, ndraws)
             logpx2 = logpdf.(dist, x2)
             @test x ≈ x2'

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -5,8 +5,7 @@ using Test
 @testset "resample" begin
     x = randn(100)
 
-    rng = MersenneTwister(42)
-
+    rng = Random.seed!(Random.default_rng(), 42)
     xsub = Pathfinder.resample(rng, x, 500)
     @test all(in.(xsub, Ref(x)))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using Pathfinder
+using Random
 using Test
+
+Random.seed!(0)
 
 @testset "Pathfinder.jl" begin
     include("transducers.jl")

--- a/test/singlepath.jl
+++ b/test/singlepath.jl
@@ -20,11 +20,12 @@ using Transducers
         else
             [MersenneTwister()]
         end
+        seed = 42
         @testset for n in [1, 5, 10, 100], rng in rngs
             executor = rng isa MersenneTwister ? SequentialEx() : ThreadedEx()
 
             x0 = randn(n)
-            Random.seed!(rng, 42)
+            Random.seed!(rng, seed)
             q, ϕ, logqϕ = @inferred pathfinder(logp, ∇logp, x0, ndraws; rng, executor)
             @test q isa MvNormal
             @test q.μ ≈ zeros(n)
@@ -35,7 +36,7 @@ using Transducers
             @test size(ϕ) == (n, ndraws)
             @test logqϕ ≈ logpdf(q, ϕ)
 
-            Random.seed!(rng, 42)
+            Random.seed!(rng, seed)
             q2, ϕ2, logqϕ2 = pathfinder(logp, ∇logp, x0, ndraws; rng, executor)
             @test q2 == q
             @test ϕ2 == ϕ
@@ -66,15 +67,16 @@ using Transducers
         else
             [MersenneTwister()]
         end
+        seed = 38
         @testset for rng in rngs
             executor = rng isa MersenneTwister ? SequentialEx() : ThreadedEx()
 
-            Random.seed!(rng, 38)
+            Random.seed!(rng, seed)
             q, ϕ, logqϕ = @inferred pathfinder(
                 logp, x₀, 10; rng, ndraws_elbo, ad_backend, executor
             )
             @test q.Σ ≈ Σ rtol = 1e-1
-            Random.seed!(rng, 38)
+            Random.seed!(rng, seed)
             q2, ϕ2, logqϕ2 = pathfinder(
                 logp, x₀, 10; rng, ndraws_elbo, ad_backend, executor
             )
@@ -83,15 +85,15 @@ using Transducers
             @test logqϕ2 == logqϕ
         end
         @testset "kwargs forwarded to solve" begin
-            rng = MersenneTwister(42)
+            Random.seed!(42)
             i = 0
             cb = (args...,) -> (i += 1; false)
-            pathfinder(logp, x₀, 10; rng)
+            pathfinder(logp, x₀, 10)
             @test i ≠ 6
 
-            rng = MersenneTwister(42)
+            Random.seed!(42)
             i = 0
-            pathfinder(logp, x₀, 10; rng, maxiters=5, cb)
+            pathfinder(logp, x₀, 10; maxiters=5, cb)
             @test i == 6
         end
     end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -6,10 +6,10 @@ function rand_pd_mat(rng, T, n)
     U = qr(randn(rng, T, n, n)).Q
     return Matrix(Symmetric(U * rand_pd_diag_mat(rng, T, n) * U'))
 end
-rand_pd_mat(T, n) = rand_pd_mat(Random.default_rng(), T, n)
+rand_pd_mat(T, n) = rand_pd_mat(Random.GLOBAL_RNG, T, n)
 
 rand_pd_diag_mat(rng, T, n) = Diagonal(rand(rng, T, n))
-rand_pd_diag_mat(T, n) = rand_pd_diag_mat(Random.default_rng(), T, n)
+rand_pd_diag_mat(T, n) = rand_pd_diag_mat(Random.GLOBAL_RNG, T, n)
 
 # defined for testing purposes
 function Pathfinder.rand_and_logpdf(rng, dist, ndraws)


### PR DESCRIPTION
Sets a global seed to be used for all tests, and avoids hard-coding use of `MersenneTwister` as the default RNG.

Supersedes #41