### PR TITLE
Simplify API

### DIFF
--- a/docs/src/multipathfinder.md
+++ b/docs/src/multipathfinder.md
@@ -47,8 +47,7 @@ init = collect.(eachcol(rand(dim, nruns) .* 20 .- 10));
 Now we run multi-path Pathfinder.
 
 ```@repl 1
-ndraws_per_run = ndraws ÷ nruns
-@time q, ϕ, component_ids = multipathfinder(logp, ∇logp, ndraws; init, ndraws_per_run);
+@time q, ϕ, component_ids = multipathfinder(logp, ∇logp, ndraws; init);
 ```
 
 The first return value is a uniformly-weighted `Distributions.MixtureModel`.

--- a/docs/src/multipathfinder.md
+++ b/docs/src/multipathfinder.md
@@ -38,16 +38,10 @@ nruns = 20
 nothing # hide
 ```
 
-Next, we create initial points for the Pathfinder runs.
-
-```@repl 1
-init = collect.(eachcol(rand(dim, nruns) .* 20 .- 10));
-```
-
 Now we run multi-path Pathfinder.
 
 ```@repl 1
-@time q, ϕ, component_ids = multipathfinder(logp, ∇logp, ndraws; init);
+@time q, ϕ, component_ids = multipathfinder(logp, ∇logp, ndraws; init_scale=10);
 ```
 
 The first return value is a uniformly-weighted `Distributions.MixtureModel`.

--- a/docs/src/multipathfinder.md
+++ b/docs/src/multipathfinder.md
@@ -41,14 +41,14 @@ nothing # hide
 Next, we create initial points for the Pathfinder runs.
 
 ```@repl 1
-θ₀s = collect.(eachcol(rand(dim, nruns) .* 20 .- 10));
+init = collect.(eachcol(rand(dim, nruns) .* 20 .- 10));
 ```
 
 Now we run multi-path Pathfinder.
 
 ```@repl 1
 ndraws_per_run = ndraws ÷ nruns
-@time q, ϕ, component_ids = multipathfinder(logp, ∇logp, θ₀s, ndraws; ndraws_per_run);
+@time q, ϕ, component_ids = multipathfinder(logp, ∇logp, ndraws; init, ndraws_per_run);
 ```
 
 The first return value is a uniformly-weighted `Distributions.MixtureModel`.

--- a/docs/src/pathfinder.md
+++ b/docs/src/pathfinder.md
@@ -31,16 +31,10 @@ end
 nothing # hide
 ```
 
-Next, we create initial points for the Pathfinder runs.
-
-```@repl 1
-θ₀ = rand(5) .* 4 .- 2  # θ₀ ~ Uniform(-2, 2);
-```
-
 Now we run Pathfinder.
 
 ```@repl 1
-@time q, ϕ, logqϕ = pathfinder(logp, ∇logp, θ₀, 100; ndraws_elbo=100);
+@time q, ϕ, logqϕ = pathfinder(logp, ∇logp; dim=5, ndraws=100, ndraws_elbo=100);
 ```
 
 The first return value is a multivariate normal approximation to our target distribution.

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -27,6 +27,7 @@ const DEFAULT_LINE_SEARCH = LineSearches.MoreThuente()
 const DEFAULT_OPTIMIZER = Optim.LBFGS(;
     m=DEFAULT_HISTORY_LENGTH, linesearch=DEFAULT_LINE_SEARCH
 )
+const DEFAULT_NDRAWS_ELBO = 5
 
 include("transducers.jl")
 include("woodbury.jl")

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -86,8 +86,9 @@ function multipathfinder(
     optim_fun::GalacticOptim.OptimizationFunction,
     ndraws::Int;
     init=nothing,
-    nruns::Int=-1,
-    ndraws_per_run::Int=5,
+    nruns::Int=init === nothing ? -1 : length(init),
+    ndraws_elbo::Int=DEFAULT_NDRAWS_ELBO,
+    ndraws_per_run::Int=max(ndraws_elbo, cld(ndraws, max(nruns, 1))),
     rng::Random.AbstractRNG=Random.GLOBAL_RNG,
     executor::Transducers.Executor=_default_executor(rng; basesize=1),
     executor_per_run=Transducers.SequentialEx(),
@@ -104,7 +105,6 @@ function multipathfinder(
         _init = fill(init, nruns)
     else
         _init = init
-        nruns = length(init)
     end
     if ndraws > ndraws_per_run * nruns
         @warn "More draws requested than total number of draws across replicas. Draws will not be unique."
@@ -119,6 +119,7 @@ function multipathfinder(
             ndraws=ndraws_per_run,
             init=init_i,
             executor=executor_per_run,
+            ndraws_elbo,
             kwargs...,
         )
     end

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -30,11 +30,11 @@ constructed using at most the previous `history_length` steps.
     Ignored if `init` is provided.
 - `init::AbstractVector{<:Real}`: initial point of length `dim` from which to begin
     optimization. If not provided, an initial point of type `Vector{Float64}` and length
-    `dim` is created and filled using `sample_init_fun`.
-- `sample_init_scale::Real`: scale factor ``s`` such that the default `sample_init_fun`
-    samples entries uniformly in the range ``[-s, s]``
-- `sample_init_fun`: function with the signature `(rng, x) -> x` that modifies a vector
-    of length `dims` in-place
+    `dim` is created and filled using `init_sampler`.
+- `init_scale::Real`: scale factor ``s`` such that the default `init_sampler` samples
+    entries uniformly in the range ``[-s, s]``
+- `init_sampler`: function with the signature `(rng, x) -> x` that modifies a vector of
+    length `dims` in-place to generate an initial point
 - `ndraws_elbo::Int=$DEFAULT_NDRAWS_ELBO`: Number of draws used to estimate the ELBO
 - `ndraws::Int=ndraws_elbo`: number of approximate draws to return
 - `ad_backend=AD.ForwardDiffBackend()`: AbstractDifferentiation.jl AD backend.
@@ -72,15 +72,15 @@ function pathfinder(
     rng=Random.GLOBAL_RNG,
     init=nothing,
     dim::Int=-1,
-    sample_init_scale=2,
-    sample_init_fun=UniformSampler(sample_init_scale),
+    init_scale=2,
+    init_sampler=UniformSampler(init_scale),
     kwargs...,
 )
     if init !== nothing
         _init = init
     elseif init === nothing && dim > 0
         _init = Vector{Float64}(undef, dim)
-        sample_init_fun(rng, _init)
+        init_sampler(rng, _init)
     else
         throw(ArgumentError("An initial point `init` or dimension `dim` must be provided."))
     end

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -138,7 +138,7 @@ struct UniformSampler{T<:Real}
     scale::T
     function UniformSampler(scale::T) where {T<:Real}
         scale > 0 || throw(DomainError(scale, "scale of uniform sampler must be positive."))
-        return UniformSampler{T}(scale)
+        return new{T}(scale)
     end
 end
 

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -150,6 +150,10 @@ Sampler that in-place modifies an array to be IID uniformly distributed on `[-sc
 struct UniformSampler{T<:Real}
     scale::T
 end
+function UniformSampler(scale::T) where {T<:Real}
+    scale > 0 || throw(DomainError(scale, "scale of uniform sampler must be positive."))
+    return UniformSampler{T}(scale)
+end
 
 function (s::UniformSampler)(rng::Random.AbstractRNG, point)
     scale = s.scale

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -19,6 +19,7 @@ constructed using at most the previous `history_length` steps.
 - `ndraws`: number of approximate draws to return
 
 # Keywords
+- `ndraws_elbo::Int=$DEFAULT_NDRAWS_ELBO`: Number of draws used to estimate the ELBO
 - `ad_backend=AD.ForwardDiffBackend()`: AbstractDifferentiation.jl AD backend.
 - `rng::Random.AbstractRNG`: The random number generator to be used for drawing samples
 - `executor::Transducers.Executor=Transducers.SequentialEx()`: Transducers.jl executor that
@@ -33,7 +34,6 @@ constructed using at most the previous `history_length` steps.
     the [GalacticOptim.jl documentation](https://galacticoptim.sciml.ai/stable) for details.
 - `history_length::Int=$DEFAULT_HISTORY_LENGTH`: Size of the history used to approximate the
     inverse Hessian. This should only be set when `optimizer` is not an `Optim.LBFGS`.
-- `ndraws_elbo::Int=5`: Number of draws used to estimate the ELBO
 - `kwargs...` : Remaining keywords are forwarded to
     [`GalacticOptim.solve`](https://galacticoptim.sciml.ai/stable/API/solve).
 
@@ -106,7 +106,7 @@ function pathfinder(
     executor::Transducers.Executor=Transducers.SequentialEx(),
     optimizer=DEFAULT_OPTIMIZER,
     history_length::Int=optimizer isa Optim.LBFGS ? optimizer.m : DEFAULT_HISTORY_LENGTH,
-    ndraws_elbo::Int=5,
+    ndraws_elbo::Int=DEFAULT_NDRAWS_ELBO,
     ndraws::Int=ndraws_elbo,
     kwargs...,
 )

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -136,10 +136,10 @@ Sampler that in-place modifies an array to be IID uniformly distributed on `[-sc
 """
 struct UniformSampler{T<:Real}
     scale::T
-end
-function UniformSampler(scale::T) where {T<:Real}
-    scale > 0 || throw(DomainError(scale, "scale of uniform sampler must be positive."))
-    return UniformSampler{T}(scale)
+    function UniformSampler(scale::T) where {T<:Real}
+        scale > 0 || throw(DomainError(scale, "scale of uniform sampler must be positive."))
+        return UniformSampler{T}(scale)
+    end
 end
 
 function (s::UniformSampler)(rng::Random.AbstractRNG, point)

--- a/test/integration/AdvancedHMC/runtests.jl
+++ b/test/integration/AdvancedHMC/runtests.jl
@@ -123,7 +123,7 @@ end
             progress=false,
         )
 
-        result_pf = pathfinder(ℓπ; dim=5)
+        result_pf = pathfinder(ℓπ; dim=5, optimizer=Optim.LBFGS(; m=6))
 
         @testset "Initial point" begin
             metric = DiagEuclideanMetric(nparams)

--- a/test/integration/AdvancedHMC/runtests.jl
+++ b/test/integration/AdvancedHMC/runtests.jl
@@ -123,8 +123,7 @@ end
             progress=false,
         )
 
-        θ₀ = rand(nparams) .* 4 .- 2
-        result_pf = pathfinder(ℓπ, θ₀, 1; optimizer=Optim.LBFGS(; m=6))
+        result_pf = pathfinder(ℓπ; dim=5)
 
         @testset "Initial point" begin
             metric = DiagEuclideanMetric(nparams)

--- a/test/integration/DynamicHMC/runtests.jl
+++ b/test/integration/DynamicHMC/runtests.jl
@@ -105,8 +105,7 @@ end
 
         logp(x) = LogDensityProblems.logdensity(P, x)
         ∇logp(x) = LogDensityProblems.logdensity_and_gradient(∇P, x)[2]
-        θ₀ = rand(LogDensityProblems.dimension(P)) .* 4 .- 2
-        result_pf = pathfinder(logp, ∇logp, θ₀, 1)
+        result_pf = pathfinder(logp, ∇logp; dim=LogDensityProblems.dimension(P))
 
         @testset "Initial point" begin
             result_hmc2 = mcmc_with_warmup(

--- a/test/multipath.jl
+++ b/test/multipath.jl
@@ -92,4 +92,17 @@ using Transducers
         fun = GalacticOptim.OptimizationFunction(logp, GalacticOptim.AutoForwardDiff())
         @test_throws ArgumentError multipathfinder(fun, 10; init)
     end
+    @testset "errors if neither dim nor init valid" begin
+        logp(x) = -sum(abs2, x) / 2
+        nruns = 2
+        @test_throws ArgumentError multipathfinder(logp, 10; nruns)
+        @test_throws ArgumentError multipathfinder(logp, 10; nruns, dim=0)
+        multipathfinder(logp, 10; nruns, dim=2)
+        multipathfinder(logp, 10; init=[randn(2) for _ in 1:nruns])
+    end
+    @testset "errors if neither init nor nruns valid" begin
+        logp(x) = -sum(abs2, x) / 2
+        @test_throws ArgumentError multipathfinder(logp, 10; dim=5, nruns=0)
+        multipathfinder(logp, 10; dim=5, nruns=2)
+    end
 end

--- a/test/multipath.jl
+++ b/test/multipath.jl
@@ -10,17 +10,16 @@ using Transducers
 
 @testset "multi path pathfinder" begin
     @testset "MvNormal" begin
-        n = 10
+        dim = 10
         nruns = 20
         ndraws = 1000_000
         ndraws_per_run = ndraws ÷ nruns
         ndraws_elbo = 100
-        Σ = rand_pd_mat(Float64, n)
-        μ = randn(n)
+        Σ = rand_pd_mat(Float64, dim)
+        μ = randn(dim)
         d = MvNormal(μ, Σ)
         logp(x) = logpdf(d, x)
         ∇logp(x) = ForwardDiff.gradient(logp, x)
-        x₀s = [rand(Uniform(-2, 2), n) for _ in 1:nruns]
         rngs = if VERSION ≥ v"1.7"
             [MersenneTwister(), Random.default_rng()]
         else
@@ -32,13 +31,13 @@ using Transducers
 
             Random.seed!(rng, seed)
             q, ϕ, component_ids = multipathfinder(
-                logp, ∇logp, x₀s, ndraws; ndraws_elbo, ndraws_per_run, rng, executor
+                logp, ∇logp, ndraws; dim, nruns, ndraws_elbo, ndraws_per_run, rng, executor
             )
             @test q isa MixtureModel
             @test ncomponents(q) == nruns
             @test Distributions.component_type(q) <: MvNormal
             @test ϕ isa AbstractMatrix
-            @test size(ϕ) == (n, ndraws)
+            @test size(ϕ) == (dim, ndraws)
             @test component_ids isa Vector{Int}
             @test length(component_ids) == ndraws
             @test extrema(component_ids) == (1, nruns)
@@ -47,18 +46,18 @@ using Transducers
             # adapted from the MvNormal tests
             # allow for 15x disagreement in atol, since this method is approximate
             multiplier = 15
-            for i in 1:n
+            for i in eachindex(μ)
                 atol = sqrt(Σ[i, i] / ndraws) * 8 * multiplier
                 @test μ_hat[i] ≈ μ[i] atol = atol
             end
-            for i in 1:n, j in 1:n
+            for i in axes(Σ, 1), j in axes(Σ, 2)
                 atol = sqrt(Σ[i, i] * Σ[j, j] / ndraws) * 10 * multiplier
                 @test isapprox(Σ_hat[i, j], Σ[i, j], atol=atol)
             end
 
             Random.seed!(rng, seed)
             q2, ϕ2, component_ids2 = multipathfinder(
-                logp, x₀s, ndraws; ndraws_elbo, ndraws_per_run, rng, executor
+                logp, ndraws; dim, nruns, ndraws_elbo, ndraws_per_run, rng, executor
             )
             @test q2 == q
             @test ϕ2 == ϕ
@@ -67,17 +66,30 @@ using Transducers
             Random.seed!(rng, seed)
             ad_backend = AD.ReverseDiffBackend()
             q3, ϕ3, component_ids3 = multipathfinder(
-                logp, x₀s, ndraws; ndraws_elbo, ndraws_per_run, rng, executor, ad_backend
+                logp,
+                ndraws;
+                dim,
+                nruns,
+                ndraws_elbo,
+                ndraws_per_run,
+                rng,
+                executor,
+                ad_backend,
             )
             for (c1, c2) in zip(q.components, q3.components)
                 @test c1 ≈ c2 atol = 1e-6
             end
         end
+
+        init = [randn(dim) for _ in 1:nruns]
+        q, ϕ, component_ids = multipathfinder(logp, ∇logp, ndraws; init)
+        @test ncomponents(q) == nruns
+        @test size(ϕ) == (dim, ndraws)
     end
     @testset "errors if no gradient provided" begin
         logp(x) = -sum(abs2, x) / 2
-        x0s = [randn(5) for _ in 1:10]
+        init = [randn(5) for _ in 1:10]
         fun = GalacticOptim.OptimizationFunction(logp, GalacticOptim.AutoForwardDiff())
-        @test_throws ArgumentError multipathfinder(fun, x0s, 10)
+        @test_throws ArgumentError multipathfinder(fun, 10; init)
     end
 end

--- a/test/multipath.jl
+++ b/test/multipath.jl
@@ -6,6 +6,7 @@ using GalacticOptim
 using Pathfinder
 using ReverseDiff
 using Test
+using Transducers
 
 @testset "multi path pathfinder" begin
     @testset "MvNormal" begin

--- a/test/singlepath.jl
+++ b/test/singlepath.jl
@@ -96,6 +96,19 @@ using Transducers
             @test i == 6
         end
     end
+    @testset "UniformSampler" begin
+        @testset for scale in [1, 2], seed in [42, 38]
+            sampler_fun = Pathfinder.UniformSampler(scale)
+            rng = Random.seed!(Random.default_rng(), seed)
+            x = zeros(100)
+            sampler_fun(rng, x)
+            @test all(-scale .≤ x .≤ scale)
+            Random.seed!(rng, seed)
+            x2 = zeros(100)
+            x2 .= rand.(rng) .* 2scale .- scale
+            @test x2 == x
+        end
+    end
     @testset "errors if no gradient provided" begin
         logp(x) = -sum(abs2, x) / 2
         init = randn(5)

--- a/test/singlepath.jl
+++ b/test/singlepath.jl
@@ -116,5 +116,13 @@ using Transducers
         @test_throws ArgumentError pathfinder(prob)
         fun = GalacticOptim.OptimizationFunction(logp, GalacticOptim.AutoForwardDiff())
         prob = GalacticOptim.OptimizationProblem(fun, init, nothing)
+        @test_throws ArgumentError pathfinder(prob)
+    end
+    @testset "errors if neither dim nor init valid" begin
+        logp(x) = -sum(abs2, x) / 2
+        @test_throws ArgumentError pathfinder(logp)
+        @test_throws ArgumentError pathfinder(logp; dim=0)
+        pathfinder(logp; dim=3)
+        pathfinder(logp; init=randn(5))
     end
 end

--- a/test/singlepath.jl
+++ b/test/singlepath.jl
@@ -97,6 +97,8 @@ using Transducers
         end
     end
     @testset "UniformSampler" begin
+        @test_throws DomainError Pathfinder.UniformSampler(-1.0)
+        @test_throws DomainError Pathfinder.UniformSampler(0.0)
         @testset for scale in [1, 2], seed in [42, 38]
             sampler_fun = Pathfinder.UniformSampler(scale)
             rng = Random.seed!(Random.default_rng(), seed)


### PR DESCRIPTION
This PR simplifies the Pathfinder API:
- Now an initial point does not need to be provided. Instead, a user can provide `dim` and optionally a sampling function, which are used to generate an initial point
- Several positional arguments are now optional arguments.