### PR TITLE
Add MeasureTheory support

### DIFF
--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -46,6 +46,11 @@ function __init__()
     Requires.@require AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d" begin
         include("integration/advancedhmc.jl")
     end
+    Requires.@require MeasureTheory = "eadaa1a4-d27c-401d-8699-e962e1bbc33b" begin
+        Requires.@require TransformVariables = "84d833dd-6860-57f9-a1a7-6da5db126cff" begin
+            include("integration/measuretheory.jl")
+        end
+    end
 end
 
 end

--- a/src/integration/measuretheory.jl
+++ b/src/integration/measuretheory.jl
@@ -3,12 +3,12 @@ using .TransformVariables: TransformVariables
 
 function pathfinder(measure::MeasureTheory.AbstractMeasure; kwargs...)
     logp = MeasureTheoryLogDensity(measure)
-    return pathfinder(logp; dim=TransformVariables.dimension(trans), kwargs...)
+    return pathfinder(logp; dim=TransformVariables.dimension(logp.transform), kwargs...)
 end
 
 function multipathfinder(measure::MeasureTheory.AbstractMeasure, ndraws::Int; kwargs...)
     logp = MeasureTheoryLogDensity(measure)
-    dim = TransformVariables.dimension(logp.trans)
+    dim = TransformVariables.dimension(logp.transform)
     return multipathfinder(logp, ndraws; dim, kwargs...)
 end
 
@@ -16,9 +16,11 @@ struct MeasureTheoryLogDensity{M,T}
     measure::M
     transform::T
 end
-MeasureTheoryLogDensity(m::Measure) = MeasureTheoryLogDensity(m, MeasureTheory.xform(m))
+function MeasureTheoryLogDensity(m::MeasureTheory.AbstractMeasure)
+    return MeasureTheoryLogDensity(m, MeasureTheory.as(m))
+end
 
-function (logp::MeasureTheoryLogDensity)(x)
-    x, logdetJ = TransformVariables.transform_and_logjac(trans, z)
-    return MeasureTheory.logdensityof(measure, x) + logdetJ
+function (logp::MeasureTheoryLogDensity)(z)
+    x, logdetJ = TransformVariables.transform_and_logjac(logp.transform, z)
+    return MeasureTheory.logdensityof(logp.measure, x) + logdetJ
 end

--- a/src/integration/measuretheory.jl
+++ b/src/integration/measuretheory.jl
@@ -1,0 +1,24 @@
+using .MeasureTheory: MeasureTheory
+using .TransformVariables: TransformVariables
+
+function pathfinder(measure::MeasureTheory.AbstractMeasure; kwargs...)
+    logp = MeasureTheoryLogDensity(measure)
+    return pathfinder(logp; dim=TransformVariables.dimension(trans), kwargs...)
+end
+
+function multipathfinder(measure::MeasureTheory.AbstractMeasure, ndraws::Int; kwargs...)
+    logp = MeasureTheoryLogDensity(measure)
+    dim = TransformVariables.dimension(logp.trans)
+    return multipathfinder(logp, ndraws; dim, kwargs...)
+end
+
+struct MeasureTheoryLogDensity{M,T}
+    measure::M
+    transform::T
+end
+MeasureTheoryLogDensity(m::Measure) = MeasureTheoryLogDensity(m, MeasureTheory.xform(m))
+
+function (logp::MeasureTheoryLogDensity)(x)
+    x, logdetJ = TransformVariables.transform_and_logjac(trans, z)
+    return MeasureTheory.logdensityof(measure, x) + logdetJ
+end

--- a/src/integration/measuretheory.jl
+++ b/src/integration/measuretheory.jl
@@ -24,3 +24,9 @@ function (logp::MeasureTheoryLogDensity)(z)
     x, logdetJ = TransformVariables.transform_and_logjac(logp.transform, z)
     return MeasureTheory.logdensityof(logp.measure, x) + logdetJ
 end
+function (logp::MeasureTheoryLogDensity{M,<:TransformVariables.ScalarTransform})(
+    z
+) where {M}
+    x, logdetJ = TransformVariables.transform_and_logjac(logp.transform, z[1])
+    return MeasureTheory.logdensityof(logp.measure, x) + logdetJ
+end


### PR DESCRIPTION
This PR adds support for calling Pathfinder on `MeasureTheory.AbstractMeasure`s. This indirectly should add support for Soss.jl and Tilde.jl, which both express conditional models as subtypes of `AbstractMeasure`

However, this code doesn't currently work for Soss, which uses an outdated version of MeasureTheory. In particular:
- Soss uses `MeasureTheory.logdensity`, which is not defined in more recent versions of MeasureTheory.
- Soss uses `xform` to get transformations, instead of `TransformVariables.as`, which MeasureTheory now uses.

cc @cscherrer