### PR TITLE
Avoid recomputing log density and gradients with Optim

### DIFF
--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -68,7 +68,7 @@ end
 
 function optimize_with_trace(
     prob,
-    optimizer::Optim.AbstractOptimizer;
+    optimizer::Union{Optim.FirstOrderOptimizer,Optim.SecondOrderOptimizer};
     progress_name="Optimizing",
     progress_id=nothing,
     maxiters=1_000,

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -65,3 +65,34 @@ function optimize_with_trace(
     GalacticOptim.solve(prob, optimizer; cb=callback, maxiters, kwargs...)
     return xs, fxs, ∇fxs
 end
+
+function optimize_with_trace(
+    prob,
+    optimizer::Optim.AbstractOptimizer;
+    progress_name="Optimizing",
+    progress_id=nothing,
+    maxiters=1_000,
+    cb=nothing,
+    kwargs...,
+)
+    iteration = 0
+    function callback(x, nfx, args...)
+        ret = cb !== nothing && cb(x, nfx, args...)
+        Base.@logmsg ProgressLogging.ProgressLevel progress_name progress =
+            iteration / maxiters _id = progress_id
+        iteration += 1
+        return ret
+    end
+    new_kwargs = merge(NamedTuple(kwargs), (; store_trace=true, extended_trace=true))
+    sol = GalacticOptim.solve(prob, optimizer; cb=callback, maxiters, new_kwargs...)
+
+    u0 = prob.u0
+    xs = Vector{typeof(u0)}(undef, iteration)
+    ∇fxs = Vector{typeof(u0)}(undef, iteration)
+    result = sol.original
+    copyto!(xs, Optim.x_trace(result))
+    fxs = -Optim.f_trace(result)
+    map!(tr -> -tr.metadata["g(x)"], ∇fxs, Optim.trace(result))
+
+    return xs, fxs, ∇fxs
+end

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -94,5 +94,5 @@ function optimize_with_trace(
     fxs = -Optim.f_trace(result)
     map!(tr -> -tr.metadata["g(x)"], ∇fxs, Optim.trace(result))
 
-    return xs, fxs, ∇fxs
+    return xs::Vector{typeof(u0)}, fxs, ∇fxs::Vector{typeof(u0)}
 end


### PR DESCRIPTION
Since GalacticOptim gives us access to the result object returned by Optim, and Optim stores the trace, we can avoid recomputing log-densities and gradients for first- and second-order optimizers in Optim. Since this covers the main usage case of Pathfinder (L-BFGS-based optimization), this can cause major speed-ups for expensive log-density functions.