### PR TITLE
Make getindex for WoodburyPDMat more efficient

### DIFF
--- a/src/integration/dynamichmc.jl
+++ b/src/integration/dynamichmc.jl
@@ -39,4 +39,10 @@ function Base.AbstractMatrix{T}(L::WoodburyLeftInvFactor) where {T}
     return WoodburyLeftInvFactor(AbstractMatrix{T}(L.A))
 end
 
-Base.getindex(L::WoodburyLeftInvFactor, inds...) = getindex(Matrix(L), inds...)
+function Base.getindex(L::WoodburyLeftInvFactor, i::Int, j::Int)
+    n = size(L, 2)
+    v = zeros(n)
+    v[j] = 1
+    mul!(v, L, v)
+    return v[i]
+end

--- a/src/woodbury.jl
+++ b/src/woodbury.jl
@@ -82,6 +82,7 @@ end
 
 function Base.getindex(W::WoodburyPDMat, i::Int, j::Int)
     B = W.B
+    isempty(B) && return W.A[i, j]
     return @views W.A[i, j] + dot(B[i, :], W.D, B[j, :])
 end
 

--- a/src/woodbury.jl
+++ b/src/woodbury.jl
@@ -80,7 +80,10 @@ function Base.AbstractMatrix{T}(W::WoodburyPDMat) where {T}
     )
 end
 
-Base.getindex(W::WoodburyPDMat, inds...) = getindex(Matrix(W), inds...)
+function Base.getindex(W::WoodburyPDMat, i::Int, j::Int)
+    B = W.B
+    return @views W.A[i, j] + dot(B[i, :], W.D, B[j, :])
+end
 
 Base.adjoint(W::WoodburyPDMat) = W
 


### PR DESCRIPTION
`getindex` for WoodburyPDMat is currently very wasteful, as it computes the entire dense matrix when only a single entry is needed. When large matrices are displayed in the REPL, this becomes very slow. This PR eliminates redundant computations for `getindex`.