### PR TITLE
Refactor internals and return intermediates in results objects

### DIFF
--- a/docs/src/multipathfinder.md
+++ b/docs/src/multipathfinder.md
@@ -2,6 +2,7 @@
 
 ```@docs
 multipathfinder
+MultiPathfinderResult
 ```
 
 ## Examples
@@ -41,31 +42,30 @@ nothing # hide
 Now we run multi-path Pathfinder.
 
 ```@repl 1
-@time q, ϕ, component_ids = multipathfinder(logp, ∇logp, ndraws; nruns, dim, init_scale=10);
+result = multipathfinder(logp, ∇logp, ndraws; nruns, dim, init_scale=10)
 ```
 
-The first return value is a uniformly-weighted `Distributions.MixtureModel`.
+`result` is a [`MultiPathfinderResult`](@ref).
+See its docstring for a description of its fields.
+
+`result.fit_dist_mix` is a uniformly-weighted `Distributions.MixtureModel`.
 Each component is the result of a single Pathfinder run.
 
-```@repl 1
-typeof(q)
-```
-
-While we could draw samples from `q` directly, these aren't equivalent to the samples returned by multi-path Pathfinder, which uses multiple importance sampling with Pareto-smoothed importance resampling to combine the individual runs.
+While we could draw samples from `result.fit_dist_mix` directly, these aren't equivalent to the samples returned by multi-path Pathfinder, which uses multiple importance sampling with Pareto-smoothed importance resampling to combine the individual runs and resample them so that, if possible, the samples can be used to estimate draws from `logp` directly.
 
 Note that [PSIS.jl](https://github.com/arviz-devs/PSIS.jl), which smooths the importance weights, warns us that the importance weights are unsuitable for computing estimates, so we should definitely run MCMC to get better samples.
 Pathfinder's samples can still be useful though for initializing MCMC.
 
-Let's compare Pathfinder's samples with samples from `q` directly, plotted over the exact marginal density.
+Let's compare Pathfinder's samples with samples from `result.fit_dist_mix` directly, plotted over the exact marginal density.
 
 ```@example 1
 using Plots
 
-τ_approx = ϕ[1, :]
-β₁_approx = ϕ[2, :]
-ϕ2 = rand(q, ndraws)
-τ_approx2 = ϕ2[1, :]
-β₁_approx2 = ϕ2[2, :]
+τ_approx = result.draws[1, :]
+β₁_approx = result.draws[2, :]
+draws2 = rand(result.fit_dist_mix, ndraws)
+τ_approx2 = draws2[1, :]
+β₁_approx2 = draws2[2, :]
 
 τ_range = -15:0.01:5
 β₁_range = -5:0.01:5
@@ -78,11 +78,11 @@ plt
 ```
 
 As expected from PSIS.jl's warning, neither set of samples cover the density well.
-But we can also see that the mixture model (`q`) places too many samples in regions of low density, which is corrected by the importance resampling.
+But we can also see that the mixture model (`result.fit_dist_mix`) places too many samples in regions of low density, which is corrected by the importance resampling.
 
 We can check how much each component contributed to the returned sample.
 
 ```@example 1
-histogram(component_ids; bins=(0:nruns) .+ 0.5, bar_width=0.8, xticks=1:nruns,
+histogram(result.draw_component_ids; bins=(0:nruns) .+ 0.5, bar_width=0.8, xticks=1:nruns,
           xlabel="Component index", ylabel="Count", legend=false)
 ```

--- a/docs/src/multipathfinder.md
+++ b/docs/src/multipathfinder.md
@@ -53,7 +53,7 @@ Each component is the result of a single Pathfinder run.
 
 While we could draw samples from `result.fit_distribution` directly, these aren't equivalent to the samples returned by multi-path Pathfinder, which uses multiple importance sampling with Pareto-smoothed importance resampling to combine the individual runs and resample them so that, if possible, the samples can be used to estimate draws from `logp` directly.
 
-Note that [PSIS.jl](https://github.com/arviz-devs/PSIS.jl), which smooths the importance weights, warns us that the importance weights are unsuitable for computing estimates, so we should definitely run MCMC to get better samples.
+Note that [PSIS.jl](https://psis.julia.arviz.org/stable/), which smooths the importance weights, warns us that the importance weights are unsuitable for computing estimates, so we should definitely run MCMC to get better samples.
 Pathfinder's samples can still be useful though for initializing MCMC.
 
 Let's compare Pathfinder's samples with samples from `result.fit_distribution` directly, plotted over the exact marginal density.

--- a/docs/src/multipathfinder.md
+++ b/docs/src/multipathfinder.md
@@ -48,22 +48,22 @@ result = multipathfinder(logp, ∇logp, ndraws; nruns, dim, init_scale=10)
 `result` is a [`MultiPathfinderResult`](@ref).
 See its docstring for a description of its fields.
 
-`result.fit_dist_mix` is a uniformly-weighted `Distributions.MixtureModel`.
+`result.fit_distribution` is a uniformly-weighted `Distributions.MixtureModel`.
 Each component is the result of a single Pathfinder run.
 
-While we could draw samples from `result.fit_dist_mix` directly, these aren't equivalent to the samples returned by multi-path Pathfinder, which uses multiple importance sampling with Pareto-smoothed importance resampling to combine the individual runs and resample them so that, if possible, the samples can be used to estimate draws from `logp` directly.
+While we could draw samples from `result.fit_distribution` directly, these aren't equivalent to the samples returned by multi-path Pathfinder, which uses multiple importance sampling with Pareto-smoothed importance resampling to combine the individual runs and resample them so that, if possible, the samples can be used to estimate draws from `logp` directly.
 
 Note that [PSIS.jl](https://github.com/arviz-devs/PSIS.jl), which smooths the importance weights, warns us that the importance weights are unsuitable for computing estimates, so we should definitely run MCMC to get better samples.
 Pathfinder's samples can still be useful though for initializing MCMC.
 
-Let's compare Pathfinder's samples with samples from `result.fit_dist_mix` directly, plotted over the exact marginal density.
+Let's compare Pathfinder's samples with samples from `result.fit_distribution` directly, plotted over the exact marginal density.
 
 ```@example 1
 using Plots
 
 τ_approx = result.draws[1, :]
 β₁_approx = result.draws[2, :]
-draws2 = rand(result.fit_dist_mix, ndraws)
+draws2 = rand(result.fit_distribution, ndraws)
 τ_approx2 = draws2[1, :]
 β₁_approx2 = draws2[2, :]
 
@@ -78,7 +78,7 @@ plt
 ```
 
 As expected from PSIS.jl's warning, neither set of samples cover the density well.
-But we can also see that the mixture model (`result.fit_dist_mix`) places too many samples in regions of low density, which is corrected by the importance resampling.
+But we can also see that the mixture model (`result.fit_distribution`) places too many samples in regions of low density, which is corrected by the importance resampling.
 
 We can check how much each component contributed to the returned sample.
 

--- a/docs/src/pathfinder.md
+++ b/docs/src/pathfinder.md
@@ -41,15 +41,15 @@ result = pathfinder(logp, ∇logp; dim=5, ndraws=100, ndraws_elbo=100)
 `result` is a [`PathfinderResult`](@ref).
 See its docstring for a description of its fields.
 
-`result.fit_dist_opt` is a multivariate normal approximation to our target distribution.
+`result.fit_distribution` is a multivariate normal approximation to our target distribution.
 Its mean and covariance are quite close to our target distribution's.
 
 ```@repl 1
-result.fit_dist_opt.μ
-result.fit_dist_opt.Σ
+result.fit_distribution.μ
+result.fit_distribution.Σ
 ```
 
-`result.draws` is a `Matrix` whose columns are the requested draws from `result.fit_dist_opt`:
+`result.draws` is a `Matrix` whose columns are the requested draws from `result.fit_distribution`:
 ```@repl 1
 result.draws
 ```

--- a/docs/src/pathfinder.md
+++ b/docs/src/pathfinder.md
@@ -45,7 +45,6 @@ See its docstring for a description of its fields.
 Its mean and covariance are quite close to our target distribution's.
 
 ```@repl 1
-result.fit_dist_opt
 result.fit_dist_opt.μ
 result.fit_dist_opt.Σ
 ```

--- a/docs/src/pathfinder.md
+++ b/docs/src/pathfinder.md
@@ -2,6 +2,7 @@
 
 ```@docs
 pathfinder
+PathfinderResult
 ```
 
 ## Examples
@@ -34,19 +35,22 @@ nothing # hide
 Now we run Pathfinder.
 
 ```@repl 1
-@time q, ϕ, logqϕ = pathfinder(logp, ∇logp; dim=5, ndraws=100, ndraws_elbo=100);
+result = pathfinder(logp, ∇logp; dim=5, ndraws=100, ndraws_elbo=100)
 ```
 
-The first return value is a multivariate normal approximation to our target distribution.
+`result` is a [`PathfinderResult`](@ref).
+See its docstring for a description of its fields.
+
+`result.fit_dist_opt` is a multivariate normal approximation to our target distribution.
 Its mean and covariance are quite close to our target distribution's.
 
 ```@repl 1
-q
-q.μ
-q.Σ
+result.fit_dist_opt
+result.fit_dist_opt.μ
+result.fit_dist_opt.Σ
 ```
 
-`ϕ` is a `Matrix` whose columns are the requested draws from `q`:
+`result.draws` is a `Matrix` whose columns are the requested draws from `result.fit_dist_opt`:
 ```@repl 1
-ϕ
+result.draws
 ```

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -19,6 +19,7 @@ using StatsBase: StatsBase
 using Transducers: Transducers
 using UnPack: @unpack
 
+export PathfinderResult, MultiPathfinderResult
 export pathfinder, multipathfinder
 
 # Note: we override the default history length to be shorter and the default line search

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -26,10 +26,11 @@ export pathfinder, multipathfinder
 # to be More-Thuente, which keeps the approximate inverse Hessian positive-definite
 const DEFAULT_HISTORY_LENGTH = 6
 const DEFAULT_LINE_SEARCH = LineSearches.MoreThuente()
-const DEFAULT_OPTIMIZER = Optim.LBFGS(;
-    m=DEFAULT_HISTORY_LENGTH, linesearch=DEFAULT_LINE_SEARCH
-)
 const DEFAULT_NDRAWS_ELBO = 5
+
+function default_optimizer(history_length)
+    return Optim.LBFGS(; m=history_length, linesearch=DEFAULT_LINE_SEARCH)
+end
 
 include("transducers.jl")
 include("woodbury.jl")

--- a/src/elbo.jl
+++ b/src/elbo.jl
@@ -29,12 +29,10 @@ struct ELBOEstimate{T,P,L<:AbstractVector{T}}
 end
 
 function Base.show(io::IO, elbo::ELBOEstimate)
-    print(
-        io,
-        "ELBO estimate ",
-        round(elbo.value; digits=2),
-        " ± ",
-        round(elbo.std_err; digits=2),
-    )
+    print(io, "ELBO estimate: ", _to_string(elbo))
     return nothing
+end
+
+function _to_string(est::ELBOEstimate; digits=2)
+    return "$(round(est.value; digits)) ± $(round(est.std_err; digits))"
 end

--- a/src/elbo.jl
+++ b/src/elbo.jl
@@ -2,11 +2,12 @@ function maximize_elbo(rng, logp, dists, ndraws, executor)
     estimate = elbo_and_samples(rng, logp, dists[begin], ndraws)
     estimates = similar(dists, typeof(estimate))
     estimates[begin] = estimate
+    length(estimates) == 1 && return 1, estimates
     @views Folds.map!(estimates[(begin + 1):end], dists[(begin + 1):end], executor) do dist
         return elbo_and_samples(rng, logp, dist, ndraws)
     end
-    _, lopt = _findmax(estimates |> Transducers.Map(est -> est.value))
-    return lopt, estimates[lopt]
+    _, lopt = _findmax(@view(estimates[2:end]) |> Transducers.Map(est -> est.value))
+    return lopt + 1, estimates
 end
 
 function elbo_and_samples(rng, logp, dist, ndraws)

--- a/src/elbo.jl
+++ b/src/elbo.jl
@@ -30,7 +30,7 @@ struct ELBOEstimate{T,P,L<:AbstractVector{T}}
     log_density_ratios::L
 end
 
-function Base.show(io::IO, elbo::ELBOEstimate)
+function Base.show(io::IO, ::MIME"text/plain", elbo::ELBOEstimate)
     print(io, "ELBO estimate: ", _to_string(elbo))
     return nothing
 end

--- a/src/elbo.jl
+++ b/src/elbo.jl
@@ -1,5 +1,7 @@
 function maximize_elbo(rng, logp, dists, ndraws, executor)
-    EE = Core.Compiler.return_type(elbo_and_samples,Tuple{typeof(rng),typeof(logp),eltype(dists),Int})
+    EE = Core.Compiler.return_type(
+        elbo_and_samples, Tuple{typeof(rng),typeof(logp),eltype(dists),Int}
+    )
     estimates = similar(dists, EE)
     isempty(estimates) && return 0, estimates
     Folds.map!(estimates, dists, executor) do dist

--- a/src/elbo.jl
+++ b/src/elbo.jl
@@ -1,22 +1,40 @@
 function maximize_elbo(rng, logp, dists, ndraws, executor)
-    elbo_ϕ_logqϕ1 = elbo_and_samples(rng, logp, dists[begin], ndraws)
-    elbo_ϕ_logqϕ = similar(dists, typeof(elbo_ϕ_logqϕ1))
-    elbo_ϕ_logqϕ[begin] = elbo_ϕ_logqϕ1
-    @views Folds.map!(
-        elbo_ϕ_logqϕ[(begin + 1):end], dists[(begin + 1):end], executor
-    ) do dist
+    estimate = elbo_and_samples(rng, logp, dists[begin], ndraws)
+    estimates = similar(dists, typeof(estimate))
+    estimates[begin] = estimate
+    @views Folds.map!(estimates[(begin + 1):end], dists[(begin + 1):end], executor) do dist
         return elbo_and_samples(rng, logp, dist, ndraws)
     end
-    _, lopt = _findmax(elbo_ϕ_logqϕ |> Transducers.Map(first))
-    return (lopt, elbo_ϕ_logqϕ[lopt]...)
+    _, lopt = _findmax(estimates |> Transducers.Map(est -> est.value))
+    return lopt, estimates[lopt]
 end
 
 function elbo_and_samples(rng, logp, dist, ndraws)
     ϕ, logqϕ = rand_and_logpdf(rng, dist, ndraws)
     logpϕ = similar(logqϕ)
     logpϕ .= logp.(eachcol(ϕ))
-    elbo = elbo_from_logpdfs(logpϕ, logqϕ)
-    return elbo, ϕ, logqϕ
+    logr = logpϕ - logqϕ
+    elbo = Statistics.mean(logr)
+    elbo_se = sqrt(Statistics.var(logr) / length(logr))
+    return ELBOEstimate(elbo, elbo_se, ϕ, logpϕ, logqϕ, logr)
 end
 
-elbo_from_logpdfs(logpϕ, logqϕ) = Statistics.mean(logpϕ) - Statistics.mean(logqϕ)
+struct ELBOEstimate{T,P,L<:AbstractVector{T}}
+    value::T
+    std_err::T
+    draws::P
+    log_densities_target::L
+    log_densities_fit::L
+    log_density_ratios::L
+end
+
+function Base.show(io::IO, elbo::ELBOEstimate)
+    print(
+        io,
+        "ELBO estimate ",
+        round(elbo.value; digits=2),
+        " ± ",
+        round(elbo.std_err; digits=2),
+    )
+    return nothing
+end

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -152,7 +152,8 @@ function multipathfinder(
     ndraws_elbo::Int=DEFAULT_NDRAWS_ELBO,
     ndraws_per_run::Int=max(ndraws_elbo, cld(ndraws, max(nruns, 1))),
     rng::Random.AbstractRNG=Random.GLOBAL_RNG,
-    optimizer=DEFAULT_OPTIMIZER,
+    history_length::Int=DEFAULT_HISTORY_LENGTH,
+    optimizer=default_optimizer(history_length),
     executor::Transducers.Executor=_default_executor(rng; basesize=1),
     executor_per_run=Transducers.SequentialEx(),
     importance::Bool=true,
@@ -179,6 +180,7 @@ function multipathfinder(
         return pathfinder(
             optim_fun;
             rng,
+            history_length,
             optimizer,
             ndraws=ndraws_per_run,
             init=init_i,

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -23,7 +23,7 @@ Container for results of multi-path Pathfinder.
 - `draws_transformed`: `draws` transformed to be draws from `fit_dist_mix_transformed`.
 - `pathfinder_results::Vector{<:PathfinderResult}`: results of each single-path Pathfinder
     run.
-- `psis_result::Union{Nothing,<:PSIS.PSISResult`: If importance resampling was used, the
+- `psis_result::Union{Nothing,<:PSIS.PSISResult}`: If importance resampling was used, the
     result of Pareto-smoothed importance resampling. `psis_result.pareto_shape` also
     diagnoses whether `draws` can be used to compute estimates from the target distribution.
 """

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -11,14 +11,14 @@ Container for results of multi-path Pathfinder.
 - `optim_prob::GalacticOptim.OptimizationProblem`: Otimization problem used for
     optimization
 - `logp`: Log-density function
-- `fit_distribution::Distributions.MixtureModel`: uniformly-weighted mixture of ELBO-maximizing
-    multivariate normal distributions from each run.
+- `fit_distribution::Distributions.MixtureModel`: uniformly-weighted mixture of ELBO-
+    maximizing multivariate normal distributions from each run.
 - `draws::AbstractMatrix{<:Real}`: draws from `fit_distribution` with size `(dim, ndraws)`,
     potentially resampled using importance resampling to be closer to the target
     distribution.
 - `draw_component_ids::Vector{Int}`: component id of each draw in `draws`.
-- `fit_distribution_transformed`: `fit_distribution` transformed to the same space as the user-
-    supplied target distribution. This is only different from `fit_distribution` when
+- `fit_distribution_transformed`: `fit_distribution` transformed to the same space as the
+    user-supplied target distribution. This is only different from `fit_distribution` when
     integrating with other packages, and its type depends on the type of `input`.
 - `draws_transformed`: `draws` transformed to be draws from `fit_distribution_transformed`.
 - `pathfinder_results::Vector{<:PathfinderResult}`: results of each single-path Pathfinder

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -26,6 +26,8 @@ Container for results of multi-path Pathfinder.
 - `psis_result::Union{Nothing,<:PSIS.PSISResult}`: If importance resampling was used, the
     result of Pareto-smoothed importance resampling. `psis_result.pareto_shape` also
     diagnoses whether `draws` can be used to compute estimates from the target distribution.
+    See [`PSIS.PSISResult`](https://psis.julia.arviz.org/stable/api/#PSIS.PSISResult) for
+    details
 """
 struct MultiPathfinderResult{I,O,R,OF,LP,FD,D,C,FDT,DT,PFR,PR}
     input::I

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -44,7 +44,8 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", result::MultiPathfinderResult)
     println(io, "Multi-path Pathfinder result")
-    print(io, "  num_runs: $(length(result.pathfinder_results))")
+    println(io, "  runs: $(length(result.pathfinder_results))")
+    print(io, "  draws: $(size(result.draws, 1))")
     psis_result = result.psis_result
     if psis_result !== nothing
         println(io)

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -128,7 +128,7 @@ function multipathfinder(
         log_densities_ratios = log_densities_target - log_densities_fit
         resample(rng, inds, log_densities_ratios, ndraws)
     else
-        resample(rng, inds, ndraws)
+        resample(rng, inds, ndraws), nothing
     end
 
     fit_dist_mix = Distributions.MixtureModel(fit_dist_opts)
@@ -137,5 +137,5 @@ function multipathfinder(
     # get component ids (k) of draws in ϕ
     draw_component_ids = cld.(sample_inds, ndraws_per_run)
 
-    return fit_dist_mix, draws, draw_component_ids
+    return (; fit_dist_mix, draws, draw_component_ids, pathfinder_results, psis_result)
 end

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -58,7 +58,7 @@ function Base.show(io::IO, ::MIME"text/plain", result::MultiPathfinderResult)
         else
             "good"
         end
-        print("  Pareto shape diagnostic: ", round(k; digits=2), " ($assessment)")
+        print(io, "  Pareto shape diagnostic: ", round(k; digits=2), " ($assessment)")
     end
     return nothing
 end

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -42,7 +42,7 @@ struct MultiPathfinderResult{I,O,R,OF,LP,FD,D,C,FDT,DT,PFR,PR}
     psis_result::PR
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", result::MultiPathfinderResult)
+function Base.show(io::IO, ::MIME"text/plain", result::MultiPathfinderResult)
     println(io, "Multi-path Pathfinder result")
     print(io, "  num_runs: $(length(result.pathfinder_results))")
     psis_result = result.psis_result
@@ -119,12 +119,7 @@ for approximating expectations with respect to ``p``.
 - `kwargs...` : Remaining keywords are forwarded to [`pathfinder`](@ref).
 
 # Returns
-- `q::Distributions.MixtureModel`: Uniformly weighted mixture of ELBO-maximizing
-    multivariate normal distributions
-- `ϕ::AbstractMatrix{<:Real}`: approximate draws from target distribution with size
-    `(dim, ndraws)`
-- `component_inds::Vector{Int}`: Indices ``k`` of components in ``q`` from which each column
-    in `ϕ` was drawn.
+- [`MultiPathfinderResult`](@ref)
 """
 function multipathfinder end
 

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -120,9 +120,12 @@ function multipathfinder(
     # draw samples from augmented mixture model
     inds = axes(draws_all, 2)
     sample_inds, psis_result = if importance
-        log_densities_fit = pathfinder_results |> Transducers.MapCat() do x
-            return Distributions.logpdf(x.fit_dist_opt, x.draws)
-        end |> collect
+        log_densities_fit =
+            pathfinder_results |>
+            Transducers.MapCat() do x
+                return Distributions.logpdf(x.fit_dist_opt, x.draws)
+            end |>
+            collect
         iter_logp = eachcol(draws_all) |> Transducers.Map(logp)
         log_densities_target = Folds.collect(iter_logp, executor)
         log_densities_ratios = log_densities_target - log_densities_fit

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -62,8 +62,8 @@ function optimize_with_trace(
         push!(∇fxs, rmul!(grad!(similar(x), x, nothing), -1))
         return ret
     end
-    GalacticOptim.solve(prob, optimizer; cb=callback, maxiters, kwargs...)
-    return xs, fxs, ∇fxs
+    sol = GalacticOptim.solve(prob, optimizer; cb=callback, maxiters, kwargs...)
+    return sol, OptimizationTrace(xs, fxs, ∇fxs)
 end
 
 function optimize_with_trace(
@@ -94,5 +94,18 @@ function optimize_with_trace(
     fxs = -Optim.f_trace(result)
     map!(tr -> -tr.metadata["g(x)"], ∇fxs, Optim.trace(result))
 
-    return xs::Vector{typeof(u0)}, fxs, ∇fxs::Vector{typeof(u0)}
+    return sol, OptimizationTrace(xs::Vector{typeof(u0)}, fxs, ∇fxs::Vector{typeof(u0)})
+end
+
+struct OptimizationTrace{P,L}
+    points::P
+    log_densities::L
+    gradients::P
+end
+
+Base.length(trace::OptimizationTrace) = length(trace.points)
+
+function Base.show(io::IO, trace::OptimizationTrace)
+    print(io, "OptimizationTrace with $(length(trace) - 1) iterations")
+    return nothing
 end

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -1,14 +1,15 @@
 """
-    resample(rng, x[, log_weights], ndraws)
+    resample(rng, x, log_weights, ndraws) -> (draws, psis_result)
+    resample(rng, x, ndraws) -> draws
 
 Draw `ndraws` samples from `x`, with replacement.
 
 If `log_weights` is provided, perform Pareto smoothed importance resampling.
 """
 function resample(rng, x, log_ratios, ndraws)
-    result = PSIS.psis(log_ratios)
-    weights = result.weights
+    psis_result = PSIS.psis(log_ratios)
+    weights = psis_result.weights
     pweights = StatsBase.ProbabilityWeights(weights, one(eltype(weights)))
-    return StatsBase.sample(rng, x, pweights, ndraws; replace=true)
+    return StatsBase.sample(rng, x, pweights, ndraws; replace=true), psis_result
 end
 resample(rng, x, ndraws) = StatsBase.sample(rng, x, ndraws; replace=true)

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -27,6 +27,9 @@ Container for results of single-path Pathfinder.
     for each point in `optim_trace`, where `fit_dists[iteration_opt + 1] == fit_dist_opt`
 - `elbo_estimates::AbstractVector{<:Pathfinder.ELBOEstimate}`: ELBO estimates for all but
     the first distribution in `fit_dists`.
+
+# Returns
+- [`PathfinderResult`](@ref)
 """
 struct PathfinderResult{I,O,R,OP,LP,FD,D,FDT,DT,OS,OT,EE}
     input::I

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -206,7 +206,7 @@ function pathfinder(
         input,
         optimizer,
         rng,
-        prob,
+        optim_solution.prob,
         logp,
         fit_dist_opt,
         draws,

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -184,7 +184,7 @@ function pathfinder(
         @warn "Pathfinder failed after $itry tries. Increase `ntries`, inspect the model for numerical instability, or provide a more suitable `init_sampler`."
     else
         elbo_estimate_opt = elbo_estimates[iteration_opt]
-        ndraws_elbo_actual = ndraws
+        ndraws_elbo_actual = ndraws_elbo
     end
 
     fit_dist_opt = fit_dists[iteration_opt + 1]

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -187,7 +187,9 @@ function pathfinder(
     fit_dist_opt = fit_dists[iteration_opt + 1]
 
     # reuse existing draws; draw additional ones if necessary
-    draws = if ndraws_elbo_actual < ndraws
+    draws = if ndraws_elbo_actual == 0
+        rand(rng, fit_dist_opt, ndraws)
+    elseif ndraws_elbo_actual < ndraws
         hcat(elbo_estimate_opt.draws, rand(rng, fit_dist_opt, ndraws - ndraws_elbo_actual))
     else
         elbo_estimate_opt.draws[:, 1:ndraws]

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -176,8 +176,12 @@ function _pathfinder(
 
     # find ELBO-maximizing distribution
     iteration_opt, elbo_estimates = @views maximize_elbo(rng, logp, fit_dists[begin+1:end], ndraws_elbo, executor)
-    elbo = elbo_estimates[iteration_opt].value
-    success &= !isnan(elbo) & (elbo != -Inf)
+    if isempty(elbo_estimates)
+        success = false
+    else
+        elbo = elbo_estimates[iteration_opt].value
+        success &= !isnan(elbo) & (elbo != -Inf)
+    end
 
     return (; success, optim_solution, optim_trace, fit_dists, iteration_opt, elbo_estimates)
 end

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -52,6 +52,7 @@ end
 function Base.show(io::IO, ::MIME"text/plain", result::PathfinderResult)
     println(io, "Single-path Pathfinder result")
     println(io, "  tries: $(result.num_tries)")
+    println(io, "  draws: $(size(result.draws, 1))")
     println(
         io, "  fit iteration: $(result.iteration_opt) / $(length(result.optim_trace) - 1)"
     )

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -172,7 +172,14 @@ function pathfinder(
     logp(x) = -prob.f.f(x, nothing)
     path_result = ProgressLogging.progress(; name="Optimizing") do progress_id
         return _pathfinder_try_until_succeed(
-            rng, prob, logp; history_length, optimizer, progress_id, ndraws_elbo, kwargs...
+            rng,
+            prob,
+            logp;
+            history_length,
+            optimizer,
+            progress_id,
+            ndraws_elbo,
+            kwargs...,
         )
     end
     @unpack (

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -95,6 +95,7 @@ end
 function pathfinder(
     prob::GalacticOptim.OptimizationProblem;
     rng::Random.AbstractRNG=Random.GLOBAL_RNG,
+    optimizer=DEFAULT_OPTIMIZER,
     ndraws_elbo::Int=DEFAULT_NDRAWS_ELBO,
     ndraws::Int=ndraws_elbo,
     kwargs...,
@@ -105,7 +106,7 @@ function pathfinder(
     logp(x) = -prob.f.f(x, nothing)
     path_result = ProgressLogging.progress(; name="Optimizing") do progress_id
         return _pathfinder_try_until_succeed(
-            rng, prob, logp; progress_id, ndraws_elbo, kwargs...
+            rng, prob, logp; optimizer, progress_id, ndraws_elbo, kwargs...
         )
     end
     @unpack itry, success, optim_solution, optim_trace, fit_dists, iteration_opt, elbo_estimates =

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -12,10 +12,11 @@ Container for results of single-path Pathfinder.
 - `optim_prob::GalacticOptim.OptimizationProblem`: Otimization problem used for
     optimization
 - `logp`: Log-density function
-- `fit_distribution::Distributions.MvNormal`: ELBO-maximizing multivariate normal distribution
+- `fit_distribution::Distributions.MvNormal`: ELBO-maximizing multivariate normal
+    distribution
 - `draws::AbstractMatrix{<:Real}`: draws from multivariate normal with size `(dim, ndraws)`
-- `fit_distribution_transformed`: `fit_distribution` transformed to the same space as the user-
-    supplied target distribution. This is only different from `fit_distribution` when
+- `fit_distribution_transformed`: `fit_distribution` transformed to the same space as the
+    user-supplied target distribution. This is only different from `fit_distribution` when
     integrating with other packages, and its type depends on the type of `input`.
 - `draws_transformed`: `draws` transformed to be draws from `fit_distribution_transformed`.
 - `fit_iteration::Int`: Iteration at which ELBO estimate was maximized
@@ -23,8 +24,9 @@ Container for results of single-path Pathfinder.
 - `optim_solution::GalacticOptim.OptimizationSolution`: Solution object of optimization.
 - `optim_trace::Pathfinder.OptimizationTrace`: container for optimization trace of points,
     log-density, and gradient. The first point is the initial point.
-- `fit_distributions::AbstractVector{Distributions.MvNormal}`: Multivariate normal distributions
-    for each point in `optim_trace`, where `fit_distributions[fit_iteration + 1] == fit_distribution`
+- `fit_distributions::AbstractVector{Distributions.MvNormal}`: Multivariate normal
+    distributions for each point in `optim_trace`, where
+    `fit_distributions[fit_iteration + 1] == fit_distribution`
 - `elbo_estimates::AbstractVector{<:Pathfinder.ELBOEstimate}`: ELBO estimates for all but
     the first distribution in `fit_distributions`.
 

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -65,10 +65,10 @@ constructed using at most the previous `history_length` steps.
 function pathfinder end
 
 function pathfinder(logp; ad_backend=AD.ForwardDiffBackend(), kwargs...)
-    return pathfinder(build_optim_function(logp; ad_backend); kwargs...)
+    return pathfinder(build_optim_function(logp; ad_backend); input=logp, kwargs...)
 end
 function pathfinder(logp, ∇logp; ad_backend=AD.ForwardDiffBackend(), kwargs...)
-    return pathfinder(build_optim_function(logp, ∇logp; ad_backend); kwargs...)
+    return pathfinder(build_optim_function(logp, ∇logp; ad_backend); input=(logp, ∇logp), kwargs...)
 end
 function pathfinder(
     optim_fun::GalacticOptim.OptimizationFunction;
@@ -77,6 +77,7 @@ function pathfinder(
     dim::Int=-1,
     init_scale=2,
     init_sampler=UniformSampler(init_scale),
+    input = optim_fun,
     kwargs...,
 )
     if init !== nothing
@@ -90,7 +91,7 @@ function pathfinder(
         throw(ArgumentError("An initial point `init` or dimension `dim` must be provided."))
     end
     prob = build_optim_problem(optim_fun, _init)
-    return pathfinder(prob; rng, init_sampler, allow_mutating_init, kwargs...)
+    return pathfinder(prob; rng, input, init_sampler, allow_mutating_init, kwargs...)
 end
 function pathfinder(
     prob::GalacticOptim.OptimizationProblem;
@@ -98,6 +99,7 @@ function pathfinder(
     optimizer=DEFAULT_OPTIMIZER,
     ndraws_elbo::Int=DEFAULT_NDRAWS_ELBO,
     ndraws::Int=ndraws_elbo,
+    input = prob,
     kwargs...,
 )
     if prob.f.grad === nothing || prob.f.grad isa Bool

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -120,9 +120,7 @@ constructed using at most the previous `history_length` steps.
     [`GalacticOptim.solve`](https://galacticoptim.sciml.ai/stable/API/solve).
 
 # Returns
-- `q::Distributions.MvNormal`: ELBO-maximizing multivariate normal distribution
-- `ϕ::AbstractMatrix{<:Real}`: draws from multivariate normal with size `(dim, ndraws)`
-- `logqϕ::Vector{<:Real}`: log-density of multivariate normal at columns of `ϕ`
+- [`PathfinderResult`](@ref)
 """
 function pathfinder end
 

--- a/test/integration/AdvancedHMC/runtests.jl
+++ b/test/integration/AdvancedHMC/runtests.jl
@@ -135,7 +135,7 @@ end
             samples2, stats2 = sample(
                 hamiltonian,
                 proposal,
-                result_pf[2][:, 1],
+                result_pf.draws[:, 1],
                 ndraws,
                 adaptor,
                 nadapts;
@@ -146,7 +146,7 @@ end
         end
 
         @testset "Initial point and metric" begin
-            metric = DiagEuclideanMetric(diag(result_pf[1].Σ))
+            metric = DiagEuclideanMetric(diag(result_pf.fit_dist_opt.Σ))
             hamiltonian = Hamiltonian(metric, ℓπ, ForwardDiff)
             ϵ = find_good_stepsize(hamiltonian, θ₀)
             integrator = Leapfrog(ϵ)
@@ -155,7 +155,7 @@ end
             samples3, stats3 = sample(
                 hamiltonian,
                 proposal,
-                result_pf[2][:, 1],
+                result_pf.draws[:, 1],
                 ndraws,
                 adaptor,
                 nadapts;
@@ -166,7 +166,7 @@ end
         end
 
         @testset "Initial point and final metric" begin
-            metric = Pathfinder.RankUpdateEuclideanMetric(result_pf[1].Σ)
+            metric = Pathfinder.RankUpdateEuclideanMetric(result_pf.fit_dist_opt.Σ)
             hamiltonian = Hamiltonian(metric, ℓπ, ForwardDiff)
             ϵ = find_good_stepsize(hamiltonian, θ₀)
             integrator = Leapfrog(ϵ)
@@ -175,7 +175,7 @@ end
             samples4, stats4 = sample(
                 hamiltonian,
                 proposal,
-                result_pf[2][:, 1],
+                result_pf.draws[:, 1],
                 ndraws,
                 adaptor,
                 nadapts;

--- a/test/integration/AdvancedHMC/runtests.jl
+++ b/test/integration/AdvancedHMC/runtests.jl
@@ -146,7 +146,7 @@ end
         end
 
         @testset "Initial point and metric" begin
-            metric = DiagEuclideanMetric(diag(result_pf.fit_dist_opt.Σ))
+            metric = DiagEuclideanMetric(diag(result_pf.fit_distribution.Σ))
             hamiltonian = Hamiltonian(metric, ℓπ, ForwardDiff)
             ϵ = find_good_stepsize(hamiltonian, θ₀)
             integrator = Leapfrog(ϵ)
@@ -166,7 +166,7 @@ end
         end
 
         @testset "Initial point and final metric" begin
-            metric = Pathfinder.RankUpdateEuclideanMetric(result_pf.fit_dist_opt.Σ)
+            metric = Pathfinder.RankUpdateEuclideanMetric(result_pf.fit_distribution.Σ)
             hamiltonian = Hamiltonian(metric, ℓπ, ForwardDiff)
             ϵ = find_good_stepsize(hamiltonian, θ₀)
             integrator = Leapfrog(ϵ)

--- a/test/integration/DynamicHMC/runtests.jl
+++ b/test/integration/DynamicHMC/runtests.jl
@@ -112,7 +112,7 @@ end
                 rng,
                 ∇P,
                 ndraws;
-                initialization=(; q=result_pf[2][:, 1]),
+                initialization=(; q=result_pf.draws[:, 1]),
                 reporter=NoProgressReport(),
             )
             @test result_hmc2.κ.M⁻¹ isa Diagonal
@@ -125,7 +125,8 @@ end
                 ∇P,
                 ndraws;
                 initialization=(;
-                    q=result_pf[2][:, 1], κ=GaussianKineticEnergy(result_pf[1].Σ)
+                    q=result_pf.draws[:, 1],
+                    κ=GaussianKineticEnergy(result_pf.fit_dist_opt.Σ),
                 ),
                 warmup_stages=default_warmup_stages(; M=Symmetric),
                 reporter=NoProgressReport(),
@@ -140,12 +141,13 @@ end
                 ∇P,
                 ndraws;
                 initialization=(;
-                    q=result_pf[2][:, 1], κ=GaussianKineticEnergy(result_pf[1].Σ)
+                    q=result_pf.draws[:, 1],
+                    κ=GaussianKineticEnergy(result_pf.fit_dist_opt.Σ),
                 ),
                 warmup_stages=default_warmup_stages(; middle_steps=0, doubling_stages=0),
                 reporter=NoProgressReport(),
             )
-            @test result_hmc4.κ.M⁻¹ === result_pf[1].Σ
+            @test result_hmc4.κ.M⁻¹ === result_pf.fit_dist_opt.Σ
             compare_estimates(identity, result_hmc4.chain, result_hmc1.chain)
         end
     end

--- a/test/integration/DynamicHMC/runtests.jl
+++ b/test/integration/DynamicHMC/runtests.jl
@@ -126,7 +126,7 @@ end
                 ndraws;
                 initialization=(;
                     q=result_pf.draws[:, 1],
-                    κ=GaussianKineticEnergy(result_pf.fit_dist_opt.Σ),
+                    κ=GaussianKineticEnergy(result_pf.fit_distribution.Σ),
                 ),
                 warmup_stages=default_warmup_stages(; M=Symmetric),
                 reporter=NoProgressReport(),
@@ -142,12 +142,12 @@ end
                 ndraws;
                 initialization=(;
                     q=result_pf.draws[:, 1],
-                    κ=GaussianKineticEnergy(result_pf.fit_dist_opt.Σ),
+                    κ=GaussianKineticEnergy(result_pf.fit_distribution.Σ),
                 ),
                 warmup_stages=default_warmup_stages(; middle_steps=0, doubling_stages=0),
                 reporter=NoProgressReport(),
             )
-            @test result_hmc4.κ.M⁻¹ === result_pf.fit_dist_opt.Σ
+            @test result_hmc4.κ.M⁻¹ === result_pf.fit_distribution.Σ
             compare_estimates(identity, result_hmc4.chain, result_hmc1.chain)
         end
     end

--- a/test/multipath.jl
+++ b/test/multipath.jl
@@ -39,15 +39,15 @@ using Transducers
             @test result.optim_fun isa GalacticOptim.OptimizationFunction
             @test result.rng === rng
             @test result.optimizer === Pathfinder.DEFAULT_OPTIMIZER
-            @test result.fit_dist_mix isa MixtureModel
-            @test ncomponents(result.fit_dist_mix) == nruns
-            @test Distributions.component_type(result.fit_dist_mix) <: MvNormal
+            @test result.fit_distribution isa MixtureModel
+            @test ncomponents(result.fit_distribution) == nruns
+            @test Distributions.component_type(result.fit_distribution) <: MvNormal
             @test result.draws isa AbstractMatrix
             @test size(result.draws) == (dim, ndraws)
             @test result.draw_component_ids isa Vector{Int}
             @test length(result.draw_component_ids) == ndraws
             @test extrema(result.draw_component_ids) == (1, nruns)
-            @test result.fit_dist_mix_transformed === result.fit_dist_mix
+            @test result.fit_distribution_transformed === result.fit_distribution
             @test result.draws_transformed == result.draws
             @test result.pathfinder_results isa Vector{<:PathfinderResult}
             @test length(result.pathfinder_results) == nruns
@@ -70,7 +70,7 @@ using Transducers
             result2 = multipathfinder(
                 logp, ndraws; dim, nruns, ndraws_elbo, ndraws_per_run, rng, executor
             )
-            @test result2.fit_dist_mix == result.fit_dist_mix
+            @test result2.fit_distribution == result.fit_distribution
             @test result2.draws == result.draws
             @test result2.draw_component_ids == result.draw_component_ids
 
@@ -88,14 +88,14 @@ using Transducers
                 ad_backend,
             )
             for (c1, c2) in
-                zip(result.fit_dist_mix.components, result3.fit_dist_mix.components)
+                zip(result.fit_distribution.components, result3.fit_distribution.components)
                 @test c1 ≈ c2 atol = 1e-6
             end
         end
 
         init = [randn(dim) for _ in 1:nruns]
         result = multipathfinder(logp, ∇logp, ndraws; init)
-        @test ncomponents(result.fit_dist_mix) == nruns
+        @test ncomponents(result.fit_distribution) == nruns
         @test size(result.draws) == (dim, ndraws)
     end
     @testset "errors if no gradient provided" begin

--- a/test/multipath.jl
+++ b/test/multipath.jl
@@ -38,7 +38,8 @@ using Transducers
             @test result.input === (logp, ∇logp)
             @test result.optim_fun isa GalacticOptim.OptimizationFunction
             @test result.rng === rng
-            @test result.optimizer === Pathfinder.DEFAULT_OPTIMIZER
+            @test result.optimizer ===
+                Pathfinder.default_optimizer(Pathfinder.DEFAULT_HISTORY_LENGTH)
             @test result.fit_distribution isa MixtureModel
             @test ncomponents(result.fit_distribution) == nruns
             @test Distributions.component_type(result.fit_distribution) <: MvNormal

--- a/test/multipath.jl
+++ b/test/multipath.jl
@@ -4,6 +4,7 @@ using ForwardDiff
 using LinearAlgebra
 using GalacticOptim
 using Pathfinder
+using PSIS
 using ReverseDiff
 using Test
 using Transducers
@@ -30,19 +31,29 @@ using Transducers
             executor = rng isa MersenneTwister ? SequentialEx() : ThreadedEx()
 
             Random.seed!(rng, seed)
-            q, ϕ, component_ids = multipathfinder(
+            result = multipathfinder(
                 logp, ∇logp, ndraws; dim, nruns, ndraws_elbo, ndraws_per_run, rng, executor
             )
-            @test q isa MixtureModel
-            @test ncomponents(q) == nruns
-            @test Distributions.component_type(q) <: MvNormal
-            @test ϕ isa AbstractMatrix
-            @test size(ϕ) == (dim, ndraws)
-            @test component_ids isa Vector{Int}
-            @test length(component_ids) == ndraws
-            @test extrema(component_ids) == (1, nruns)
-            μ_hat = mean(ϕ; dims=2)
-            Σ_hat = cov(ϕ .- μ_hat; dims=2, corrected=false)
+            @test result isa MultiPathfinderResult
+            @test result.input === (logp, ∇logp)
+            @test result.optim_fun isa GalacticOptim.OptimizationFunction
+            @test result.rng === rng
+            @test result.optimizer === Pathfinder.DEFAULT_OPTIMIZER
+            @test result.fit_dist_mix isa MixtureModel
+            @test ncomponents(result.fit_dist_mix) == nruns
+            @test Distributions.component_type(result.fit_dist_mix) <: MvNormal
+            @test result.draws isa AbstractMatrix
+            @test size(result.draws) == (dim, ndraws)
+            @test result.draw_component_ids isa Vector{Int}
+            @test length(result.draw_component_ids) == ndraws
+            @test extrema(result.draw_component_ids) == (1, nruns)
+            @test result.fit_dist_mix_transformed === result.fit_dist_mix
+            @test result.draws_transformed == result.draws
+            @test result.pathfinder_results isa Vector{<:PathfinderResult}
+            @test length(result.pathfinder_results) == nruns
+            @test result.psis_result isa PSIS.PSISResult
+            μ_hat = mean(result.draws; dims=2)
+            Σ_hat = cov(result.draws .- μ_hat; dims=2, corrected=false)
             # adapted from the MvNormal tests
             # allow for 15x disagreement in atol, since this method is approximate
             multiplier = 15
@@ -56,16 +67,16 @@ using Transducers
             end
 
             Random.seed!(rng, seed)
-            q2, ϕ2, component_ids2 = multipathfinder(
+            result2 = multipathfinder(
                 logp, ndraws; dim, nruns, ndraws_elbo, ndraws_per_run, rng, executor
             )
-            @test q2 == q
-            @test ϕ2 == ϕ
-            @test component_ids2 == component_ids
+            @test result2.fit_dist_mix == result.fit_dist_mix
+            @test result2.draws == result.draws
+            @test result2.draw_component_ids == result.draw_component_ids
 
             Random.seed!(rng, seed)
             ad_backend = AD.ReverseDiffBackend()
-            q3, ϕ3, component_ids3 = multipathfinder(
+            result3 = multipathfinder(
                 logp,
                 ndraws;
                 dim,
@@ -76,15 +87,16 @@ using Transducers
                 executor,
                 ad_backend,
             )
-            for (c1, c2) in zip(q.components, q3.components)
+            for (c1, c2) in
+                zip(result.fit_dist_mix.components, result3.fit_dist_mix.components)
                 @test c1 ≈ c2 atol = 1e-6
             end
         end
 
         init = [randn(dim) for _ in 1:nruns]
-        q, ϕ, component_ids = multipathfinder(logp, ∇logp, ndraws; init)
-        @test ncomponents(q) == nruns
-        @test size(ϕ) == (dim, ndraws)
+        result = multipathfinder(logp, ∇logp, ndraws; init)
+        @test ncomponents(result.fit_dist_mix) == nruns
+        @test size(result.draws) == (dim, ndraws)
     end
     @testset "errors if no gradient provided" begin
         logp(x) = -sum(abs2, x) / 2

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -18,12 +18,16 @@ include("test_utils.jl")
         prob = Pathfinder.build_optim_problem(fun, θ₀)
         optimizer = Optim.LBFGS()
         history_length = optimizer.m
-        θs, logpθs, ∇logpθs = Pathfinder.optimize_with_trace(prob, optimizer)
-        Σs = Pathfinder.lbfgs_inverse_hessians(θs, ∇logpθs; history_length)
-        dists = @inferred Pathfinder.fit_mvnormals(θs, ∇logpθs; history_length)
+        _, optim_trace = Pathfinder.optimize_with_trace(prob, optimizer)
+        Σs = Pathfinder.lbfgs_inverse_hessians(
+            optim_trace.points, optim_trace.gradients; history_length
+        )
+        dists = @inferred Pathfinder.fit_mvnormals(
+            optim_trace.points, optim_trace.gradients; history_length
+        )
         @test dists isa Vector{<:MvNormal{Float64,<:Pathfinder.WoodburyPDMat}}
         @test Σs ≈ getproperty.(dists, :Σ)
-        @test θs .+ Σs .* ∇logpθs ≈ getproperty.(dists, :μ)
+        @test optim_trace.points .+ Σs .* optim_trace.gradients ≈ getproperty.(dists, :μ)
     end
 
     @testset "rand_and_logpdf" begin

--- a/test/optimize.jl
+++ b/test/optimize.jl
@@ -66,20 +66,24 @@ end
         Optim.BFGS(), Optim.LBFGS(), Optim.ConjugateGradient(), NLopt.Opt(:LD_LBFGS, n)
     ]
     @testset "$(typeof(optimizer))" for optimizer in optimizers
-        xs, fxs, ∇fxs = Pathfinder.optimize_with_trace(prob, optimizer)
-        @test xs[1] ≈ x0
-        @test xs[end] ≈ μ
-        @test fxs ≈ f.(xs)
-        @test ∇fxs ≈ ∇f.(xs) atol = 1e-4
+        optim_sol, optim_trace = Pathfinder.optimize_with_trace(prob, optimizer)
+        @test optim_sol isa GalacticOptim.SciMLBase.OptimizationSolution
+        @test optim_trace isa Pathfinder.OptimizationTrace
+        @test optim_trace.points[1] ≈ x0
+        @test optim_sol.prob.u0 ≈ x0
+        @test optim_trace.points[end] ≈ μ
+        @test optim_sol.u ≈ μ
+        @test optim_trace.log_densities ≈ f.(optim_trace.points)
+        @test optim_trace.gradients ≈ ∇f.(optim_trace.points) atol = 1e-4
 
         if !(optimizer isa NLopt.Opt)
             options = Optim.Options(; store_trace=true, extended_trace=true)
             res = Optim.optimize(
                 x -> -f(x), (y, x) -> copyto!(y, -∇f(x)), x0, optimizer, options
             )
-            @test Optim.iterations(res) == length(xs) - 1
-            @test Optim.x_trace(res) ≈ xs
-            @test Optim.minimizer(res) ≈ xs[end]
+            @test Optim.iterations(res) == length(optim_trace.points) - 1
+            @test Optim.x_trace(res) ≈ optim_trace.points
+            @test Optim.minimizer(res) ≈ optim_trace.points[end]
         end
     end
 

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -1,4 +1,5 @@
 using Pathfinder
+using PSIS
 using Random
 using Test
 
@@ -12,6 +13,7 @@ using Test
     # weight the first 20% much higher than the remaining 80%
     log_weights = randn(100)
     log_weights[1:20] .+= 1_000
-    xsub = Pathfinder.resample(rng, x, log_weights, 500)
+    xsub, result = Pathfinder.resample(rng, x, log_weights, 500)
     @test all(in.(xsub, Ref(x[1:20])))
+    @test result isa PSIS.PSISResult
 end

--- a/test/singlepath.jl
+++ b/test/singlepath.jl
@@ -32,7 +32,8 @@ using Transducers
             @test result.optim_prob isa GalacticOptim.OptimizationProblem
             @test result.logp(init) ≈ logp(init)
             @test result.rng === rng
-            @test result.optimizer === Pathfinder.DEFAULT_OPTIMIZER
+            @test result.optimizer ===
+                Pathfinder.default_optimizer(Pathfinder.DEFAULT_HISTORY_LENGTH)
             fit_distribution = result.fit_distribution
             @test fit_distribution isa MvNormal
             @test fit_distribution.μ ≈ zeros(dim)

--- a/test/singlepath.jl
+++ b/test/singlepath.jl
@@ -48,13 +48,13 @@ using Transducers
             @test result.optim_trace isa Pathfinder.OptimizationTrace
             @test result.fit_distributions isa Vector{typeof(fit_distribution)}
             @test length(result.fit_distributions) == length(result.optim_trace)
-            @test result.fit_distributions[result.iteration_opt + 1] == fit_distribution
-            @test result.iteration_opt ==
+            @test result.fit_distributions[result.fit_iteration + 1] == fit_distribution
+            @test result.fit_iteration ==
                 argmax(getproperty.(result.elbo_estimates, :value))
 
             Random.seed!(rng, seed)
             result2 = pathfinder(logp, ∇logp; init, ndraws, rng, executor)
-            @test result2.iteration_opt == result.iteration_opt
+            @test result2.fit_iteration == result.fit_iteration
             @test result2.draws == result.draws
             @test getproperty.(result2.elbo_estimates, :value) ==
                 getproperty.(result.elbo_estimates, :value)
@@ -129,7 +129,7 @@ using Transducers
             init = randn(dim)
             result2 = pathfinder(logp; init, cb, ntries=nfail)
             @test !isapprox(result2.fit_distribution.μ, zeros(dim); atol=1e-6)
-            @test result2.iteration_opt == 0
+            @test result2.fit_iteration == 0
             @test isempty(result2.elbo_estimates)
             @test result2.num_tries == nfail
             @test result2.optim_prob.u0 == result2.optim_trace.points[1]


### PR DESCRIPTION
This PR is a major refactor of the internals so that intermediates can be returned in `PathfinderResult` and `MultiPathfinderResult` objects.