### PR TITLE
Use default basesize in parallel executor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -114,8 +114,8 @@ for approximating expectations with respect to ``p``.
     use a parallelization-friendly PRNG like the default PRNG on Julia 1.7 and up.
 - `executor::Transducers.Executor`: Transducers.jl executor that determines if and how
     to run the single-path runs in parallel. If `rng` is known to be thread-safe, the
-    default is `Transducers.PreferParallel(; basesize=1)` (parallel executation, defaulting
-    to multi-threading). Otherwise, it is `Transducers.SequentialEx()` (no parallelization).
+    default is `Transducers.PreferParallel()` (parallel executation, defaulting to
+    multi-threading). Otherwise, it is `Transducers.SequentialEx()` (no parallelization).
 - `executor_per_run::Transducers.Executor=Transducers.SequentialEx()`: Transducers.jl
     executor used within each run to parallelize PRNG calls. Defaults to no parallelization.
     See [`pathfinder`](@ref) for a description.
@@ -154,7 +154,7 @@ function multipathfinder(
     rng::Random.AbstractRNG=Random.GLOBAL_RNG,
     history_length::Int=DEFAULT_HISTORY_LENGTH,
     optimizer=default_optimizer(history_length),
-    executor::Transducers.Executor=_default_executor(rng; basesize=1),
+    executor::Transducers.Executor=_default_executor(rng),
     executor_per_run=Transducers.SequentialEx(),
     importance::Bool=true,
     kwargs...,


### PR DESCRIPTION
We set the `basesize` to 1 so that each run that finishes automatically updates the progress log. However, Transducers does this by using `nruns` threads, which is very bad when `nruns` is much larger than the number of cores. If we use the default `basesize`, then Transducers chunks the runs across `Threads.nthreads()` available threads, and each run finishes more quickly.