### PR TITLE
Reuse memory for ELBO calculation

### DIFF
--- a/src/mvnormal.jl
+++ b/src/mvnormal.jl
@@ -19,13 +19,13 @@ function fit_mvnormals(θs, ∇logpθs; kwargs...)
 end
 
 # faster than computing `logpdf` and `rand` independently
-function rand_and_logpdf(rng, dist::Distributions.MvNormal, ndraws)
+function rand_and_logpdf!(rng, u, dist::Distributions.MvNormal, ndraws)
     μ = dist.μ
     Σ = dist.Σ
     N = length(μ)
 
     # draw points
-    u = Random.randn!(rng, similar(μ, N, ndraws))
+    Random.randn!(rng, u)
     unormsq = vec(sum(abs2, u; dims=1))
     x = PDMats.unwhiten!(u, Σ, u)
     x .+= μ


### PR DESCRIPTION
I noticed this line:
```julia
u = Random.randn!(rng, similar(μ, N, ndraws))
```
This allocates a new `u` on each iteration, which will have some overhead. This PR removes that, instead allocating `u` once in `maximize_elbo` and reusing it.

Some caveats:
1. This didn't have nearly the impact I expected
2. Tests are not yet updated for this

That said, here's the test case:
```julia
using Pathfinder

rosenbrock(x) = @inbounds -(1-x[1])^2  - 100 * (x[2] - x[1]^2)^2

using BenchmarkTools
result = pathfinder(rosenbrock; init=zeros(2))
```

The result is
```julia
julia> result = pathfinder(rosenbrock; init=zeros(2))
Single-path Pathfinder result
  tries: 1
  draws: 5
  fit iteration: 7 (total: 22)
  fit ELBO: -2.77 ± 0.78
  fit distribution: Distributions.MvNormal{Float64, Pathfinder.WoodburyPDMat{Float64, LinearAlgebra.Diagonal{Float64, Vector{Float64}}, Matrix{Float64}, Matrix{Float64}, LinearAlgebra.Diagonal{Float64, Vector{Float64}}, LinearAlgebra.QRCompactWYQ{Float64, Matrix{Float64}, Matrix{Float64}}, LinearAlgebra.UpperTriangular{Float64, Matrix{Float64}}}, Vector{Float64}}(
dim: 2
μ: [0.658221, 0.418772]
Σ: [0.122998 0.13468; 0.13468 0.151634]
)
```

Note that there are 22 ELBO evaluations.

Now for benchmarking. 

**BEFORE**
```julia
julia> @benchmark result = pathfinder(rosenbrock; init=zeros(2))
BenchmarkTools.Trial: 4835 samples with 1 evaluation.
 Range (min … max):  902.530 μs …   8.335 ms  ┊ GC (min … max): 0.00% … 79.29%
 Time  (median):     966.893 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.030 ms ± 514.814 μs  ┊ GC (mean ± σ):  3.46% ±  6.15%

 Memory estimate: 293.51 KiB, allocs estimate: 3359.
```

**AFTER**
```julia
julia> @benchmark result = pathfinder(rosenbrock; init=zeros(2))
BenchmarkTools.Trial: 4957 samples with 1 evaluation.
 Range (min … max):  898.102 μs …  12.059 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     956.924 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.005 ms ± 503.189 μs  ┊ GC (mean ± σ):  3.37% ± 6.15%

 Memory estimate: 290.55 KiB, allocs estimate: 3338.
```

Now 3359 - 3338 = 21, because we've allocated once instead of 22 times.

It's very minor in this case, but maybe much larger problems could require many more ELBO evaluations. Then again, in those cases the non-allocation overhead will also be much higher.