### PR TITLE
Fixes for compatibility with recent PDMats versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.4.6"
+version = "0.4.7"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,15 +15,12 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
-        "Library" => [
-            "Public" => "lib/public.md",
-            "Internals" => "lib/internals.md",
-        ],
+        "Library" => ["Public" => "lib/public.md", "Internals" => "lib/internals.md"],
         "Examples" => [
             "Quickstart" => "examples/quickstart.md",
             "Initializing HMC" => "examples/initializing-hmc.md",
             "Turing usage" => "examples/turing.md",
-        ]
+        ],
     ],
 )
 

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -56,7 +56,8 @@ function Base.show(io::IO, ::MIME"text/plain", result::PathfinderResult)
     println(io, "  tries: $(result.num_tries)")
     println(io, "  draws: $(size(result.draws, 2))")
     println(
-        io, "  fit iteration: $(result.fit_iteration) (total: $(length(result.optim_trace) - 1))"
+        io,
+        "  fit iteration: $(result.fit_iteration) (total: $(length(result.optim_trace) - 1))",
     )
     println(io, "  fit ELBO: $(_to_string(result.elbo_estimates[result.fit_iteration]))")
     print(io, "  fit distribution: ", result.fit_distribution)

--- a/src/woodbury.jl
+++ b/src/woodbury.jl
@@ -138,6 +138,11 @@ function Base.:*(W::WoodburyPDMat, c::Real)
     return WoodburyPDMat(W.A * c, W.B * one(c), W.D * c)
 end
 
+function Base.size(W::WoodburyPDMat)
+    n = size(W.A, 1)
+    return (n, n)
+end
+
 PDMats.dim(W::WoodburyPDMat) = size(W.A, 1)
 
 function PDMats.invquad(W::WoodburyPDMat, x::AbstractVector{T}) where {T}

--- a/src/woodbury.jl
+++ b/src/woodbury.jl
@@ -118,7 +118,7 @@ function LinearAlgebra.diag(W::WoodburyPDMat)
     return diag(W.A) + map(b -> dot(b, D, b), eachrow(W.B))
 end
 
-function LinearAlgebra.lmul!(W::WoodburyPDMat, x::StridedVecOrMat)
+function LinearAlgebra.lmul!(W::WoodburyPDMat, x::AbstractVecOrMat)
     UA = W.UA
     UC = W.UC
     Q = W.Q
@@ -133,10 +133,7 @@ function LinearAlgebra.lmul!(W::WoodburyPDMat, x::StridedVecOrMat)
     return x
 end
 
-function LinearAlgebra.mul!(y::AbstractVector, W::WoodburyPDMat, x::StridedVecOrMat)
-    return lmul!(W, copyto!(y, x))
-end
-function LinearAlgebra.mul!(y::AbstractMatrix, W::WoodburyPDMat, x::StridedVecOrMat)
+function LinearAlgebra.mul!(y::AbstractVector, W::WoodburyPDMat, x::AbstractVecOrMat)
     return lmul!(W, copyto!(y, x))
 end
 
@@ -159,7 +156,7 @@ function PDMats.invquad(W::WoodburyPDMat, x::AbstractVector{T}) where {T}
     return @views sum(abs2, W.UC' \ v[1:k]) + sum(abs2, v[(k + 1):n])
 end
 
-function PDMats.invquad!(r::AbstractArray, W::WoodburyPDMat, x::StridedMatrix{T}) where {T}
+function PDMats.invquad!(r::AbstractArray, W::WoodburyPDMat, x::AbstractMatrix{T}) where {T}
     v = lmul!(W.Q', W.UA' \ x)
     k = minimum(size(W.B))
     @views ldiv!(W.UC', v[1:k, :])
@@ -167,7 +164,7 @@ function PDMats.invquad!(r::AbstractArray, W::WoodburyPDMat, x::StridedMatrix{T}
     return r
 end
 
-function PDMats.quad!(r::AbstractArray, W::WoodburyPDMat, x::StridedMatrix{T}) where {T}
+function PDMats.quad!(r::AbstractArray, W::WoodburyPDMat, x::AbstractMatrix{T}) where {T}
     v = lmul!(W.Q', W.UA * x)
     k = minimum(size(W.B))
     @views lmul!(W.UC, v[1:k, :])
@@ -183,7 +180,7 @@ function PDMats.quad(W::WoodburyPDMat, x::AbstractVector{T}) where {T}
 end
 
 function PDMats.unwhiten!(
-    r::StridedVecOrMat{T}, W::WoodburyPDMat, x::StridedVecOrMat{T}
+    r::AbstractVecOrMat{T}, W::WoodburyPDMat, x::AbstractVecOrMat{T}
 ) where {T}
     k = minimum(size(W.B))
     copyto!(r, x)
@@ -194,7 +191,7 @@ function PDMats.unwhiten!(
 end
 
 function invunwhiten!(
-    r::StridedVecOrMat{T}, W::WoodburyPDMat, x::StridedVecOrMat{T}
+    r::AbstractVecOrMat{T}, W::WoodburyPDMat, x::AbstractVecOrMat{T}
 ) where {T}
     k = minimum(size(W.B))
     copyto!(r, x)

--- a/src/woodbury.jl
+++ b/src/woodbury.jl
@@ -72,6 +72,13 @@ function WoodburyPDMat(A, B, D)
     )
 end
 
+function Base.getproperty(W::WoodburyPDMat, k::Symbol)
+    k === :dim && return size(W, 1)
+    return getfield(W, k)
+end
+
+Base.propertynames(W::WoodburyPDMat) = (:dim, fieldnames(typeof(W))...)
+
 Base.Matrix(W::WoodburyPDMat) = Matrix(Symmetric(muladd(W.B, W.D * W.B', W.A)))
 
 function Base.AbstractMatrix{T}(W::WoodburyPDMat) where {T}

--- a/src/woodbury.jl
+++ b/src/woodbury.jl
@@ -203,12 +203,12 @@ end
 
 # adapted from https://github.com/JuliaStats/PDMats.jl/blob/master/src/utils.jl
 function colwise_sumsq!(r::AbstractArray, a::AbstractMatrix)
-    n = length(r)
-    @assert n == size(a, 2)
-    @inbounds for j in 1:n
+    eachindex(r) == axes(a, 2) ||
+        throw(DimensionMismatch("Inconsistent argument dimensions."))
+    for j in axes(a, 2)
         v = zero(eltype(a))
         @simd for i in axes(a, 1)
-            v += abs2(a[i, j])
+            @inbounds v += abs2(a[i, j])
         end
         r[j] = v
     end

--- a/test/woodbury.jl
+++ b/test/woodbury.jl
@@ -29,7 +29,7 @@ function test_decompositions(W)
 end
 
 @testset "WoodburyPDMat" begin
-    @testset "A $Atype, D $Dtype" for T in (Float64, Float32),
+    @testset "A $Atype, D $Dtype eltype $T" for T in (Float64, Float32),
         Atype in (:dense, :diag),
         Dtype in (:dense, :diag),
         n in (5, 10),
@@ -85,6 +85,12 @@ end
         @testset "adjoint/transpose" begin
             @test W' === W
             @test transpose(W) === W
+        end
+
+        @testset "+ ::UniformScaling" begin
+            c = randn(T) * I
+            @test W + c ≈ Wmat + c
+            @test c + W ≈ c + Wmat
         end
 
         @testset "lmul!" begin

--- a/test/woodbury.jl
+++ b/test/woodbury.jl
@@ -45,6 +45,8 @@ end
             @test eltype(W) === T
             @test eltype(Wmat) === T
             @test size(W) == (n, n)
+            @test size(W, 1) == n
+            @test size(W, 2) == n
             @test Matrix(W) ≈ Wmat
             @test W[3, 5] ≈ Wmat[3, 5]
             @test W ≈ Wmat


### PR DESCRIPTION
This PR makes a few internal changes motivated by recent changes to PDMats:
- define `size(::WoodburyPDMat)`, since https://github.com/JuliaStats/PDMats.jl/pull/170 deleted the generic `size(::AbstractPDMat)` method
- temporarily add `+(::WoodburyPDMat, ::UniformScaling)` methods to work around https://github.com/JuliaStats/PDMats.jl/pull/170 adding only to this method for `AbstractPDMat` the requirement that the `.dim` property be defined.
- make matching changes to those in https://github.com/JuliaStats/PDMats.jl/pull/163