### PR TITLE
Use Optim.jl directly for Optim solvers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.7.1"
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Folds = "41a02a25-b8f0-4f67-bc48-60067656b558"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
@@ -38,6 +39,7 @@ TuringExt = ["DynamicPPL", "MCMCChains", "Turing"]
 [compat]
 Accessors = "0.1"
 Distributions = "0.25"
+DocStringExtensions = "0.9"
 DynamicPPL = "0.20, 0.21"
 Folds = "0.2"
 ForwardDiff = "0.10"

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -36,6 +36,7 @@ end
 
 include("transducers.jl")
 include("woodbury.jl")
+include("trace.jl")
 include("optimize.jl")
 include("inverse_hessian.jl")
 include("mvnormal.jl")

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -1,6 +1,7 @@
 module Pathfinder
 
 using Distributions: Distributions
+using DocStringExtensions
 using Folds: Folds
 # ensure that ForwardDiff is conditionally loaded by Optimization
 using ForwardDiff: ForwardDiff
@@ -37,6 +38,7 @@ end
 include("transducers.jl")
 include("woodbury.jl")
 include("trace.jl")
+include("callbacks.jl")
 include("optimize.jl")
 include("inverse_hessian.jl")
 include("mvnormal.jl")

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -108,11 +108,11 @@ A callback to log progress with a `reporter`
 
 $(FIELDS)
 """
-Base.@kwdef mutable struct ProgressCallback{R} <: AbstractOptimizationCallback
+Base.@kwdef mutable struct ProgressCallback{R,U} <: AbstractOptimizationCallback
     "Reporter function, called with signature `report(progress_id, maxiters, try_id, iter_id)`"
     @const reporter::R
     "An identifier for the progress bar."
-    @const progress_id::Base.UUID
+    @const progress_id::U
     "Maximum number of iterations"
     @const maxiters::Int
     "Index of the current try"
@@ -133,7 +133,7 @@ $(SIGNATURES)
 
 Report progress using ProgressLogging.jl.
 """
-function report_progress(progress_id::Base.UUID, maxiters::Int, try_id::Int, iter_id::Int)
+function report_progress(progress_id, maxiters::Int, try_id::Int, iter_id::Int)
     Base.@logmsg ProgressLogging.ProgressLevel "Optimizing (try $(try_id))" progress =
         iter_id / maxiters _id = progress_id
     return nothing

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,0 +1,161 @@
+# utility macro to annotate a field as const only if supported
+@eval macro $(Symbol("const"))(x)
+    if VERSION ≥ v"1.8"
+        Expr(:const, esc(x))
+    else
+        esc(x)
+    end
+end
+
+# callbacks for Optimization.jl
+
+"""
+$(TYPEDEF)
+
+Abstract type for Optimization.jl callbacks.
+
+A callback should be a callable with the signature
+
+    (x, f(x), args...) -> Bool
+
+where `x` is the parameter being optimized, and `f` is the objective function. A return
+value of `true` signals that optimization should stop.
+
+See the [Optimization.jl docs](https://docs.sciml.ai/Optimization/stable/API/solve/) for
+more information.
+"""
+abstract type AbstractOptimizationCallback end
+
+"""
+$(TYPEDEF)
+
+A sequence of Optimization.jl callbacks to be executed in order.
+"""
+struct CallbackSequence{C<:Tuple} <: AbstractOptimizationCallback
+    "Tuple of Optimization.jl callbacks to be called in order"
+    callbacks::C
+end
+
+"""
+$(SIGNATURES)
+
+Wrap the sequence `callbacks`.
+"""
+CallbackSequence(callbacks...) = CallbackSequence(callbacks)
+
+function (callback::CallbackSequence)(args...)
+    return mapfoldl(|, callback.callbacks; init=false) do cb
+        cb === nothing && return false
+        return cb(args...)
+    end
+end
+
+"""
+$(TYPEDEF)
+
+A callback to log progress with a `reporter`
+
+# Fields
+
+$(FIELDS)
+"""
+Base.@kwdef mutable struct ProgressCallback{R} <: AbstractOptimizationCallback
+    "Reporter function, called with signature `report(progress_id, maxiters, try_id, iter_id)`"
+    @const reporter::R
+    "An identifier for the progress bar."
+    @const progress_id::Base.UUID
+    "Maximum number of iterations"
+    @const maxiters::Int
+    "Index of the current try"
+    try_id::Int
+    "Index of the current iteration"
+    iter_id::Int
+end
+
+function (cb::ProgressCallback)(args...)
+    cb.iter_id += 1
+    return false
+end
+(::ProgressCallback{Nothing})(args...) = false
+
+"""
+$(SIGNATURES)
+
+Report progress using ProgressLogging.jl.
+"""
+function report_progress(progress_id::Base.UUID, maxiters::Int, try_id::Int, iter_id::Int)
+    Base.@logmsg ProgressLogging.ProgressLevel "Optimizing (try $(try_id))" progress =
+        iter_id / maxiters _id = progress_id
+    return nothing
+end
+
+"""
+$(TYPEDEF)
+
+A callback that signals termination if the objective value is non-finite and `fail=true`.
+"""
+struct CheckFiniteValueCallback <: AbstractOptimizationCallback
+    "Whether to raise an error if the objective function is non-finite"
+    fail::Bool
+end
+
+function (cb::CheckFiniteValueCallback)(x, fx, ∇fx, args...)
+    return cb.fail && isnan(fx) || fx == -Inf || any(!isfinite, ∇fx)
+end
+
+struct FillTraceCallback{G,T<:OptimizationTrace} <: AbstractOptimizationCallback
+    "A function to compute the gradient of the objective function"
+    grad::G
+    "An `Optimization` with empty vectors to be filled."
+    trace::T
+end
+
+function (cb::FillTraceCallback)(x, fx, args...)
+    # NOTE: Optimization doesn't have an interface for accessing the gradient trace,
+    # so we need to recompute it ourselves
+    # see https://github.com/SciML/Optimization.jl/issues/149
+    ∇fx = cb.grad(x)
+    rmul!(∇fx, -1)
+
+    trace = cb.trace
+    # some backends mutate x, so we must copy it
+    push!(trace.points, copy(x))
+    push!(trace.log_densities, -fx)
+    push!(trace.gradients, ∇fx)
+    return false
+end
+
+# callbacks for Optim.jl
+
+"""
+$(TYPEDEF)
+
+Abstract type for Optim.jl callbacks.
+
+A callback should be a callable with the signature
+
+    (states::Vector{<:AbstractOptimizerState}) -> Bool
+
+where `x` is the parameter being optimized, and `f` is the objective function. A return
+value of `true` signals that optimization should stop.
+"""
+abstract type AbstractOptimJLCallback end
+
+"""
+$(TYPEDEF)
+
+Adaptor for an Optimization.jl callback to be an Optim.jl callback.
+"""
+struct OptimJLCallbackAdaptor{C} <: AbstractOptimJLCallback
+    "An Optimization.jl callback to be called."
+    callback::C
+end
+
+function (cb::OptimJLCallbackAdaptor)(states)
+    state = states[end]
+    md = state.metadata
+    x = md["x"]
+    fx = state.value
+    return cb.callback(x, fx, md["g(x)"])
+end
+(::OptimJLCallbackAdaptor{Nothing})(states) = false

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -1,4 +1,95 @@
-function build_optim_function(ℓ)
+"""
+$(TYPEDEF)
+
+A callable that wraps a LogDensityProblem to be an `fgh!` callable for Optim.jl.
+
+See the [Optim.jl docs](https://julianlsolvers.github.io/Optim.jl/stable/#user/tipsandtricks/#avoid-repeating-computations)
+for details.
+
+# Fields
+
+$(TYPEDFIELDS)
+"""
+struct OptimJLFunction{P}
+    "An object that implements the LogDensityProblem interface"
+    prob::P
+end
+
+# avoid repeated computation by computing the highest order derivative required and not
+# recomputing the lower order ones
+function (fun::OptimJLFunction)(F, G, H, x)
+    prob = fun.prob
+    if H !== nothing
+        lp, glp, Hlp = LogDensityProblems.logdensity_gradient_and_hessian(prob, x)
+        @. H = -Hlp
+        if G !== nothing
+            @. G = -glp
+        end
+        F === nothing || return -lp
+    elseif G !== nothing
+        lp, glp = LogDensityProblems.logdensity_and_gradient(prob, x)
+        @. G = -glp
+        F === nothing || return -lp
+    elseif F !== nothing
+        return -LogDensityProblems.logdensity(prob, x)
+    end
+    return nothing
+end
+
+"""
+$(TYPEDEF)
+
+A utility object to mimic a `SciMLBase.OptimizationProblem` for use with Optim.jl.
+
+# Fields
+
+$(TYPEDFIELDS)
+"""
+struct OptimJLProblem{F<:OptimJLFunction,U<:AbstractVector{<:Real}}
+    "An optimization function."
+    fun::F
+    "Initial point"
+    u0::U
+end
+
+function _defines_gradient(fun::SciMLBase.OptimizationFunction)
+    return fun.grad !== nothing && !(fun.grad isa Bool)
+end
+_defines_gradient(prob::SciMLBase.OptimizationProblem) = _defines_gradient(prob.f)
+_defines_gradient(::Any) = true
+
+"""
+$(SIGNATURES)
+
+Construct a log-density function with signature `x -> Real` from an optimization function.
+"""
+get_logp(fun::SciMLBase.OptimizationFunction) = Base.Fix2((-) ∘ fun.f, nothing)
+get_logp(fun::OptimJLFunction) = Base.Fix1(LogDensityProblems.logdensity, fun.prob)
+
+"""
+$(SIGNATURES)
+
+Construct a log-density function with signature `x -> Real` from an optimization problem.
+"""
+get_logp(prob::SciMLBase.OptimizationProblem) = get_logp(prob.f)
+get_logp(prob::OptimJLProblem) = get_logp(prob.fun)
+
+"""
+$(SIGNATURES)
+
+Build an optimization function from the LogDensityProblem `ℓ`.
+
+The type of the returned object is determined by `optimizer`, either an
+[`OptimJLFunction`](@ref) or a `SciMLBase.OptimizationFunction`.
+"""
+build_optim_function(ℓ, optimizer) = _build_sciml_optim_function(ℓ)
+function build_optim_function(
+    ℓ, ::Union{Optim.FirstOrderOptimizer,Optim.SecondOrderOptimizer}
+)
+    return OptimJLFunction(ℓ)
+end
+
+function _build_sciml_optim_function(ℓ)
     f(x, p) = -LogDensityProblems.logdensity(ℓ, x)
     function grad(res, x, p)
         _, ∇fx = LogDensityProblems.logdensity_and_gradient(ℓ, x)
@@ -13,14 +104,36 @@ function build_optim_function(ℓ)
     return SciMLBase.OptimizationFunction{true}(f; grad, hess)
 end
 
+"""
+$(SIGNATURES)
+
+Build an optimization problem from the LogDensityProblem `ℓ` and initial point `x₀`.
+
+The type of the returned object is determined by `optimizer`, either an
+[`OptimJLProbkem`](@ref) or a `SciMLBase.OptimizationProblem`.
+"""
 function build_optim_problem(optim_fun, x₀)
     return SciMLBase.OptimizationProblem(optim_fun, x₀, nothing)
 end
+function build_optim_problem(optim_fun::OptimJLFunction, x₀)
+    return OptimJLProblem(optim_fun, x₀)
+end
 
+"""
+$(SIGNATURES)
+
+# Returns
+
+- `sol`: The optimization solution, either a `SciMLBase.OptimizationSolution` or a
+    `Optim.MultivariateOptimizationResults`
+- `trace::OptimizationTrace`: the optimization trace, where the first point is the initial
+    one.
+"""
 function optimize_with_trace(
-    prob,
+    prob::SciMLBase.OptimizationProblem,
     optimizer;
-    progress_name="Optimizing",
+    reporter=report_progress,
+    try_id=1,
     progress_id=nothing,
     maxiters=1_000,
     callback=nothing,
@@ -29,46 +142,66 @@ function optimize_with_trace(
 )
     u0 = prob.u0
     fun = prob.f
-    function ∇f(x)
+
+    function grad(x)
         SciMLBase.isinplace(fun) || return fun.grad(x, nothing)
         res = similar(x)
         fun.grad(res, x, nothing)
-        rmul!(res, -1)
         return res
     end
-    # caches for the trace of x and f(x)
+
+    # allocate containers for the trace of x and f(x)
     xs = typeof(u0)[]
     fxs = typeof(fun.f(u0, nothing))[]
     ∇fxs = typeof(u0)[]
-    _callback = _make_optimization_callback(
-        xs, fxs, ∇fxs, ∇f; progress_name, progress_id, maxiters, callback, fail_on_nonfinite
+    trace = OptimizationTrace(xs, fxs, ∇fxs)
+
+    _callback = CallbackSequence(
+        callback,
+        ProgressCallback(; reporter, progress_id, try_id, maxiters, iter_id=0),
+        CheckFiniteValueCallback(fail_on_nonfinite),
+        FillTraceCallback(grad, trace),
     )
     sol = Optimization.solve(prob, optimizer; callback=_callback, maxiters, kwargs...)
-    return sol, OptimizationTrace(xs, fxs, ∇fxs)
+    return sol, trace
 end
-
-function _make_optimization_callback(
-    xs, fxs, ∇fxs, ∇f; progress_name, progress_id, maxiters, callback, fail_on_nonfinite
+function optimize_with_trace(
+    prob::OptimJLProblem,
+    optimizer::Union{Optim.FirstOrderOptimizer,Optim.SecondOrderOptimizer};
+    reporter=report_progress,
+    try_id=1,
+    progress_id=nothing,
+    maxiters=1_000,
+    callback=nothing,
+    fail_on_nonfinite=true,
+    kwargs...,
 )
-    return function (x, nfx, args...)
-        ret = callback !== nothing && callback(x, nfx, args...)
-        iteration = length(xs)
-        Base.@logmsg ProgressLogging.ProgressLevel progress_name progress =
-            iteration / maxiters _id = progress_id
+    _callback = OptimJLCallbackAdaptor(
+        CallbackSequence(
+            callback,
+            ProgressCallback(; reporter, progress_id, try_id, maxiters, iter_id=0),
+            CheckFiniteValueCallback(fail_on_nonfinite),
+        ),
+    )
+    options = Optim.Options(;
+        callback=_callback,
+        store_trace=true,
+        extended_trace=true,
+        iterations=maxiters,
+        kwargs...,
+    )
+    result = Optim.optimize(Optim.only_fgh!(prob.fun), prob.u0, optimizer, options)
 
-        # some backends mutate x, so we must copy it
-        push!(xs, copy(x))
-        push!(fxs, -nfx)
-        # NOTE: Optimization doesn't have an interface for accessing the gradient trace,
-        # so we need to recompute it ourselves
-        # see https://github.com/SciML/Optimization.jl/issues/149
-        ∇fx = ∇f(x)
-        push!(∇fxs, ∇fx)
+    u0 = prob.u0
+    xtrace = Optim.x_trace(result)
+    iterations = min(length(xtrace) - 1, Optim.iterations(result))
 
-        if fail_on_nonfinite && !ret
-            ret = (isnan(nfx) || nfx == -Inf || any(!isfinite, ∇fx))::Bool
-        end
+    # containers for the trace of x and ∇f(x)
+    xs = Vector{typeof(u0)}(undef, iterations + 1)
+    ∇fxs = Vector{typeof(u0)}(undef, iterations + 1)
 
-        return ret
-    end
+    copyto!(xs, xtrace)
+    fxs = -Optim.f_trace(result)
+    map!(tr -> -tr.metadata["g(x)"], ∇fxs, Optim.trace(result))
+    return result, OptimizationTrace(xs, fxs, ∇fxs)
 end

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -72,16 +72,3 @@ function _make_optimization_callback(
         return ret
     end
 end
-
-struct OptimizationTrace{P,L}
-    points::P
-    log_densities::L
-    gradients::P
-end
-
-Base.length(trace::OptimizationTrace) = length(trace.points)
-
-function Base.show(io::IO, trace::OptimizationTrace)
-    print(io, "OptimizationTrace with $(length(trace) - 1) iterations")
-    return nothing
-end

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -1,0 +1,24 @@
+"""
+    $(TYPEDEF)
+
+A container for the trajectory of points and values computed during optimization.
+
+# Fields
+
+$(FIELDS)
+"""
+struct OptimizationTrace{P,L}
+    "Points in the optimization trajectory"
+    points::P
+    "Log-density (negative objective function) values at `points`"
+    log_densities::L
+    "Gradient of the log-density values at `points`"
+    gradients::P
+end
+
+Base.length(trace::OptimizationTrace) = length(trace.points)
+
+function Base.show(io::IO, trace::OptimizationTrace)
+    print(io, "OptimizationTrace with $(length(trace) - 1) iterations")
+    return nothing
+end

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -1,0 +1,126 @@
+using ForwardDiff, Optim, Pathfinder, Test, UUIDs
+
+include("test_utils.jl")
+
+struct DummyCallback{C,D}
+    cond1::C
+    cond2::D
+end
+
+function (cb::DummyCallback)(x, fx, args...)
+    return cb.cond1(x) || cb.cond2(fx)
+end
+
+@testset "callbacks" begin
+    @testset "CallbackSequence" begin
+        cb = Pathfinder.CallbackSequence(
+            DummyCallback(iszero, iszero), DummyCallback(isnan, Base.Fix1(any, isnan))
+        )
+        @inferred cb(1.0, [2.0, 3.0], nothing)
+        @test !cb(1.0, [2.0, 3.0], nothing)
+        @test cb(0.0, [2.0, 3.0], nothing)
+        @test cb(1.0, [0.0, 0.0])
+        @test cb(NaN, [1.0, 2.0])
+        @test cb(1.0, [NaN, 2.0])
+    end
+
+    @testset "CheckFiniteValueCallback" begin
+        x = randn(3)
+        cb = Pathfinder.CheckFiniteValueCallback(true)
+        @inferred cb(x, 1.0, nothing)
+        @test !cb(x, 1.0)
+        @test !cb(x, 2.0)
+        @test cb(x, NaN)
+        @test cb(x, -Inf)
+
+        cb2 = Pathfinder.CheckFiniteValueCallback(false)
+        @inferred cb2(x, 1.0, nothing)
+        @test !cb2(x, 1.0)
+        @test !cb2(x, 2.0)
+        @test !cb2(x, NaN)
+        @test !cb2(x, -Inf)
+    end
+
+    @testset "FillTraceCallback" begin
+        trace = Pathfinder.OptimizationTrace(
+            Vector{Float64}[], Float64[], Vector{Float64}[]
+        )
+        grad(x) = x / 4
+        cb = Pathfinder.FillTraceCallback(grad, trace)
+        xs = [randn(10) for _ in 1:3]
+        fxs = rand(3)
+        for i in eachindex(xs, fxs)
+            @test !cb(xs[i], fxs[i], nothing)
+            @test length(trace.points) ==
+                length(trace.log_densities) ==
+                length(trace.gradients) ==
+                i
+            @test trace.points[i] == xs[i]
+            @test trace.log_densities[i] == -fxs[i]
+            @test trace.gradients[i] == -grad(xs[i])
+        end
+    end
+
+    @testset "ProgressCallback" begin
+        @testset for maxiters in [10, 100], try_id in 1:2
+            progress_id = UUIDs.uuid1()
+            progress_trace = []
+            reporter = function (progress_id, maxiters, try_id, iter_id)
+                push!(progress_trace, (progress_id, maxiters, try_id, iter_id))
+                return nothing
+            end
+            cb = Pathfinder.ProgressCallback(;
+                reporter, progress_id, maxiters, try_id, iter_id=0
+            )
+            @testset for i in 1:3
+                @test !cb(randn(10), rand(), nothing)
+                @test length(progress_trace) == i
+                @test progress_trace[i] == (progress_id, maxiters, try_id, i - 1)
+            end
+            cb2 = Pathfinder.ProgressCallback(;
+                reporter=nothing, progress_id, maxiters, try_id, iter_id=0
+            )
+            @test !cb2(randn(10), rand(), nothing)
+        end
+    end
+
+    @testset "report_progress" begin
+        @testset for maxiters in (10, 100), try_id in (1, 2)
+            logs, = Test.collect_test_logs(; min_level=ProgressLogging.ProgressLevel) do
+                ProgressLogging.progress(; name="Optimizing") do progress_id
+                    for iter_id in 0:maxiters
+                        Pathfinder.report_progress(progress_id, maxiters, try_id, iter_id)
+                    end
+                end
+            end
+            @test length(logs) == maxiters + 3
+            @test logs[1].kwargs[:progress] === nothing
+            @test logs[1].message == "Optimizing"
+            for i in 0:maxiters
+                @test logs[i + 2].kwargs[:progress] == i / maxiters
+                @test logs[i + 2].message == "Optimizing (try $try_id)"
+            end
+            @test logs[maxiters + 3].kwargs[:progress] == "done"
+        end
+    end
+
+    @testset "OptimJLCallback" begin
+        f(x) = -logp_banana(x)
+        grad(x) = ForwardDiff.gradient(f, x)
+        trace = Pathfinder.OptimizationTrace(
+            Vector{Float64}[], Float64[], Vector{Float64}[]
+        )
+        callback = Pathfinder.OptimJLCallbackAdaptor(
+            Pathfinder.FillTraceCallback(grad, trace)
+        )
+        x0 = randn(2)
+        options = Optim.Options(; callback, store_trace=true, extended_trace=true)
+        sol = Optim.optimize(f, x0, LBFGS(), options)
+        @test trace.points == Optim.x_trace(sol)
+        @test trace.log_densities == -Optim.f_trace(sol)
+        @test trace.gradients ≈ -[t.metadata["g(x)"] for t in sol.trace]
+
+        cb2 = Pathfinder.OptimJLCallbackAdaptor(nothing)
+        @test !cb2([])
+    end
+end

--- a/test/multipath.jl
+++ b/test/multipath.jl
@@ -37,7 +37,7 @@ include("test_utils.jl")
             )
             @test result isa MultiPathfinderResult
             @test result.input === ℓ
-            @test result.optim_fun isa SciMLBase.OptimizationFunction
+            @test result.optim_fun isa Pathfinder.OptimJLFunction
             @test result.rng === rng
             @test result.optimizer ===
                 Pathfinder.default_optimizer(Pathfinder.DEFAULT_HISTORY_LENGTH)

--- a/test/optimize.jl
+++ b/test/optimize.jl
@@ -1,4 +1,5 @@
 using LinearAlgebra
+using LogDensityProblems
 using Optim
 using OptimizationNLopt
 using Pathfinder
@@ -12,68 +13,48 @@ include("test_utils.jl")
     n = 20
     ℓ = build_logdensityproblem(logp_banana, n)
     x = randn(n)
-    fun = Pathfinder.build_optim_function(ℓ)
-    @test fun isa SciMLBase.OptimizationFunction
-    @test SciMLBase.isinplace(fun)
-    @test fun.f(x, nothing) ≈ -ℓ.logp(x)
-    ∇fx = similar(x)
-    fun.grad(∇fx, x, nothing)
-    @test ∇fx ≈ -ℓ.∇logp(x)
-    H = similar(x, n, n)
-    fun.hess(H, x, nothing)
-    @test H ≈ -ℓ.∇²logp(x)
+
+    @testset for optimizer in (Optim.LBFGS(), Optim.Newton())
+        fun = @inferred Pathfinder.build_optim_function(ℓ, optimizer)
+        @test fun isa Pathfinder.OptimJLFunction
+        @test fun.prob === ℓ
+    end
+
+    @testset for optimizer in (NLopt.Opt(:LD_LBFGS, n),)
+        fun = @inferred Pathfinder.build_optim_function(ℓ, optimizer)
+        @test fun isa SciMLBase.OptimizationFunction
+        @test SciMLBase.isinplace(fun)
+        @test fun.f(x, nothing) ≈ -ℓ.logp(x)
+        ∇fx = similar(x)
+        fun.grad(∇fx, x, nothing)
+        @test ∇fx ≈ -ℓ.∇logp(x)
+        H = similar(x, n, n)
+        fun.hess(H, x, nothing)
+        @test H ≈ -ℓ.∇²logp(x)
+    end
 end
 
 @testset "build_optim_problem" begin
     n = 20
     ℓ = build_logdensityproblem(logp_banana, n)
     x0 = randn(n)
-    fun = Pathfinder.build_optim_function(ℓ)
-    prob = Pathfinder.build_optim_problem(fun, x0)
-    @test SciMLBase.isinplace(prob)
-    @test prob isa SciMLBase.OptimizationProblem
-    @test prob.f === fun
-    @test prob.u0 == x0
-    @test prob.p === nothing
-end
 
-@testset "_make_optimization_callback" begin
-    @testset "callback return value" begin
-        progress_name = "Optimizing"
-        progress_id = nothing
-        maxiters = 1_000
-        x = randn(5)
-        check_vals = [0.0, NaN, -Inf, Inf]
-        @testset for fail_on_nonfinite in [true, false],
-            fval in check_vals,
-            gval in check_vals,
-            cbfail in [true, false]
+    @testset "OptimJLFunction" begin
+        fun = Pathfinder.OptimJLFunction(ℓ)
+        prob = @inferred Pathfinder.build_optim_problem(fun, x0)
+        @test prob isa Pathfinder.OptimJLProblem
+        @test prob.fun === fun
+        @test prob.u0 === x0
+    end
 
-            xs = Vector{Float64}[]
-            fxs = Float64[]
-            ∇fxs = Vector{Float64}[]
-            ∇f = function (x)
-                g = -x
-                g[end] = gval
-                return g
-            end
-            callback = (x, fx, args...) -> cbfail
-            cb = Pathfinder._make_optimization_callback(
-                xs,
-                fxs,
-                ∇fxs,
-                ∇f;
-                progress_name,
-                progress_id,
-                maxiters,
-                callback,
-                fail_on_nonfinite,
-            )
-            should_fail =
-                cbfail ||
-                (fail_on_nonfinite && (isnan(fval) || fval == Inf || !isfinite(gval)))
-            @test cb(x, -fval) == should_fail
-        end
+    @testset "SciML.OptimizationFunction" begin
+        fun = Pathfinder._build_sciml_optim_function(ℓ)
+        prob = Pathfinder.build_optim_problem(fun, x0)
+        @test SciMLBase.isinplace(prob)
+        @test prob isa SciMLBase.OptimizationProblem
+        @test prob.f === fun
+        @test prob.u0 == x0
+        @test prob.p === nothing
     end
 end
 
@@ -85,8 +66,6 @@ end
     ℓ = build_logdensityproblem(f, n)
 
     x0 = randn(n)
-    fun = Pathfinder.build_optim_function(ℓ)
-    prob = Pathfinder.build_optim_problem(fun, x0)
 
     optimizers = [
         "Optim.BFGS" => Optim.BFGS(),
@@ -95,37 +74,44 @@ end
         "NLopt.Opt" => NLopt.Opt(:LD_LBFGS, n),
     ]
     @testset "$name" for (name, optimizer) in optimizers
+        fun = Pathfinder.build_optim_function(ℓ, optimizer)
+        prob = Pathfinder.build_optim_problem(fun, x0)
         optim_sol, optim_trace = Pathfinder.optimize_with_trace(prob, optimizer)
-        @test optim_sol isa SciMLBase.OptimizationSolution
         @test optim_trace isa Pathfinder.OptimizationTrace
         @test optim_trace.points[1] ≈ x0
         @test optim_trace.points[end] ≈ μ
-        @test optim_sol.u ≈ μ
         @test optim_trace.log_densities ≈ f.(optim_trace.points)
         @test optim_trace.gradients ≈ ℓ.∇logp.(optim_trace.points) atol = 1e-4
 
-        if !(optimizer isa NLopt.Opt)
+        if optimizer isa Union{Optim.FirstOrderOptimizer,Optim.SecondOrderOptimizer}
+            @test optim_sol isa Optim.MultivariateOptimizationResults
+
             options = Optim.Options(; store_trace=true, extended_trace=true)
             res = Optim.optimize(
                 x -> -f(x), (y, x) -> copyto!(y, -ℓ.∇logp(x)), x0, optimizer, options
             )
-            @test Optim.iterations(res) == length(optim_trace.points) - 1
-            @test Optim.x_trace(res) ≈ optim_trace.points
-            @test Optim.minimizer(res) ≈ optim_trace.points[end]
+            @test Optim.iterations(res) == Optim.iterations(optim_sol)
+            @test Optim.x_trace(res) ≈ Optim.x_trace(optim_sol)
+            @test Optim.minimizer(res) ≈ Optim.minimizer(optim_sol)
+        else
+            @test optim_sol isa SciMLBase.OptimizationSolution
+            @test optim_sol.u ≈ μ
         end
-    end
 
-    @testset "progress logging" begin
-        logs, = Test.collect_test_logs(; min_level=ProgressLogging.ProgressLevel) do
-            ProgressLogging.progress(; name="Optimizing") do progress_id
-                Pathfinder.optimize_with_trace(prob, Optim.LBFGS(); progress_id)
+        @testset "progress logging" begin
+            @testset for try_id in 1:2
+                logs, = Test.collect_test_logs(; min_level=ProgressLogging.ProgressLevel) do
+                    ProgressLogging.progress(; name="Optimizing") do progress_id
+                        Pathfinder.optimize_with_trace(prob, Optim.LBFGS(); progress_id, try_id)
+                    end
+                end
+                @test logs[1].kwargs[:progress] === nothing
+                @test logs[1].message == "Optimizing"
+                @test logs[2].kwargs[:progress] == 0.0
+                @test logs[2].message == "Optimizing (try $try_id)"
+                @test logs[3].kwargs[:progress] == 0.001
+                @test logs[end].kwargs[:progress] == "done"
             end
         end
-        @test logs[1].kwargs[:progress] === nothing
-        @test logs[1].message == "Optimizing"
-        @test logs[2].kwargs[:progress] == 0.0
-        @test logs[2].message == "Optimizing"
-        @test logs[3].kwargs[:progress] == 0.001
-        @test logs[end].kwargs[:progress] == "done"
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ Random.seed!(0)
 @testset "Pathfinder.jl" begin
     include("transducers.jl")
     include("woodbury.jl")
+    include("callbacks.jl")
     include("optimize.jl")
     include("inverse_hessian.jl")
     include("mvnormal.jl")

--- a/test/singlepath.jl
+++ b/test/singlepath.jl
@@ -27,10 +27,13 @@ include("test_utils.jl")
             ℓ = build_logdensityproblem(logp, 5)
             init = randn(dim)
             Random.seed!(rng, seed)
-            result = @inferred pathfinder(ℓ; init, ndraws, rng, executor)
+            result = @inferred Pathfinder.PathfinderResult pathfinder(
+                ℓ; init, ndraws, rng, executor
+            )
             @test result isa PathfinderResult
             @test result.input === ℓ
-            @test result.optim_prob isa SciMLBase.OptimizationProblem
+            @test result.optim_prob isa Pathfinder.OptimJLProblem
+            @test result.optim_solution isa Optim.MultivariateOptimizationResults
             @test result.logp(init) ≈ logp(init)
             @test result.rng === rng
             @test result.optimizer ===
@@ -46,7 +49,6 @@ include("test_utils.jl")
             @test result.fit_distribution_transformed === result.fit_distribution
             @test result.draws_transformed === result.draws
             @test result.num_tries ≥ 1
-            @test result.optim_solution isa SciMLBase.OptimizationSolution
             @test result.optim_trace isa Pathfinder.OptimizationTrace
             @test result.fit_distributions isa Vector{typeof(fit_distribution)}
             @test length(result.fit_distributions) == length(result.optim_trace)
@@ -93,7 +95,9 @@ include("test_utils.jl")
             executor = rng isa MersenneTwister ? SequentialEx() : ThreadedEx()
 
             Random.seed!(rng, seed)
-            result = @inferred pathfinder(ℓ; rng, optimizer, ndraws_elbo, executor)
+            result = @inferred Pathfinder.PathfinderResult pathfinder(
+                ℓ; rng, optimizer, ndraws_elbo, executor
+            )
             @test result.input === ℓ
             @test result.fit_distribution.Σ ≈ Σ rtol = 1e-1
             @test result.optimizer == optimizer


### PR DESCRIPTION
With LogDensityProblems, we have the ability to simultaneously compute the log density, its gradient, and even its Hessian. Optim.jl supports this kind of interface that shares work; however, Optimization.jl does not.

This PR changes the internals of Pathfinder to use Optim.jl whenever a LogDensityProblem and an Optim.jl optimizer are provided. In the best case, this halves the amount of work performed by Pathfinder. Since the optimization solution stored in `PathfinderResult` can now be one of two types, this change is marked as breaking.