### PR TITLE
ci: remove enable-beta-ecosystems flag from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests


### PR DESCRIPTION
Julia ecosystem support in Dependabot is no longer in beta, so this flag is unnecessary.