### PR TITLE
feat: support post-hoc PSIS (re)sampling with(out) replacement

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
-version = "0.10.4"
+version = "0.10.5"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
 
 [workspace]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -63,6 +63,7 @@ withenv("COLUMNS" => 100) do
             "Examples" => [
                 "Quickstart" => "examples/quickstart.md",
                 "Initializing HMC" => "examples/initializing-hmc.md",
+                "Resampling" => "examples/resampling.md",
                 "Turing usage" => "examples/turing.md",
             ],
             "References" => "references.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -62,8 +62,8 @@ withenv("COLUMNS" => 100) do
             "Library" => ["Public" => "lib/public.md", "Internals" => "lib/internals.md"],
             "Examples" => [
                 "Quickstart" => "examples/quickstart.md",
-                "Initializing HMC" => "examples/initializing-hmc.md",
                 "Resampling" => "examples/resampling.md",
+                "Initializing HMC" => "examples/initializing-hmc.md",
                 "Turing usage" => "examples/turing.md",
             ],
             "References" => "references.md",

--- a/docs/src/examples/initializing-hmc.md
+++ b/docs/src/examples/initializing-hmc.md
@@ -118,6 +118,11 @@ result_dhmc1 = mcmc_with_warmup(
 )
 ```
 
+!!! tip "Initializing multiple chains"
+    When initializing several independent chains from a [`multipathfinder`](@ref) result, use
+    [`resample`](@ref) with `replace=false` to obtain distinct starting points.
+    See [Resampling](@ref) for details.
+
 ### Initializing metric adaptation from Pathfinder's estimate
 
 To start with Pathfinder's inverse metric estimate, we just need to initialize a [`DynamicHMC.GaussianKineticEnergy`](@extref) object with it as input: 

--- a/docs/src/examples/initializing-hmc.md
+++ b/docs/src/examples/initializing-hmc.md
@@ -119,8 +119,7 @@ result_dhmc1 = mcmc_with_warmup(
 ```
 
 !!! tip "Initializing multiple chains"
-    When initializing several independent chains from a [`multipathfinder`](@ref) result, use
-    [`resample`](@ref) with `replace=false` to obtain distinct starting points.
+    When initializing several independent chains from a [`multipathfinder`](@ref) result, use [`resample`](@ref) with `replace=false` to obtain distinct starting points.
     See [Resampling](@ref) for details.
 
 ### Initializing metric adaptation from Pathfinder's estimate

--- a/docs/src/examples/resampling.md
+++ b/docs/src/examples/resampling.md
@@ -19,7 +19,7 @@ since it has a poor Pareto-``\hat{k}`` diagnostic.
 ```@example 1
 using Pathfinder, Random
 
-Random.seed!(23)
+Random.seed!(99)
 
 logp_banana(x) = -(x[1]^2 + 5(x[2] - x[1]^2)^2) / 2
 

--- a/docs/src/examples/resampling.md
+++ b/docs/src/examples/resampling.md
@@ -5,53 +5,59 @@ are stored in the result.
 [`resample`](@ref) lets you draw new samples from this approximation without re-running Pathfinder.
 Two common workflows are:
 
-1. **Selecting unique MCMC initialization points**: When the Pareto shape ``\hat{k}`` is large,
-   importance resampling *without replacement* yields at most one draw per unique candidate —
-   suitable as distinct starting points for independent MCMC chains.
-2. **Requesting more draws**: When the original run used too few `ndraws_per_run`, fresh draws
-   can be generated from the fitted mixture and importance-resampled, without re-fitting.
+1. **Selecting unique MCMC initialization points**: When the Pareto shape ``k`` is large, the default importance resampling *with replacement* can result in all returned draws being identical.
+   Importance resampling *without replacement* yields at most one draw per unique candidate, which is more suitable as distinct starting points for independent MCMC chains.
+2. **Requesting more draws**: When the original run used too few `ndraws_per_run`, fresh draws can be generated from the fitted mixture and importance-resampled, without re-fitting, at the cost of additional log-density evaluations.
 
 ## Setup
 
-We use the banana-shaped distribution from the [Quickstart](@ref) as our running example,
-since it has a poor Pareto-``\hat{k}`` diagnostic.
+We use the funnel distribution from the [Quickstart](@ref "A 100-dimensional funnel") as our running example.
 
 ```@example 1
-using Pathfinder, Random
+using ADTypes, Pathfinder, Random, ReverseDiff
 
-Random.seed!(99)
+Random.seed!(68)
 
-logp_banana(x) = -(x[1]^2 + 5(x[2] - x[1]^2)^2) / 2
+function logp_funnel(x)
+    n = length(x)
+    τ = x[1]
+    β = view(x, 2:n)
+    return ((τ / 3)^2 + (n - 1) * τ + sum(b -> abs2(b * exp(-τ / 2)), β)) / -2
+end
 
-result = multipathfinder(logp_banana, 200; dim=2, nruns=20, init_scale=10)
+ndraws = 200
+result = multipathfinder(logp_funnel, ndraws; dim=100, nruns=20, init_scale=10, adtype=AutoReverseDiff())
 ```
 
-The large Pareto shape ``\hat{k}`` indicates that these draws are unreliable for computing
-posterior estimates, and we should run MCMC to get better samples.
+The Pareto shape ``k`` diagnostic is very bad, indicating that the importance resampled draws do not represent the target distribution very well.
+Sometimes this means that only a small number of distinct draws are proposed:
 
 ```@example 1
-result.psis_result.pareto_shape
+ndraws_distinct = length(unique(eachcol(result.draws)))
+ndraws_distinct / ndraws  # fraction of draws that are distinct
 ```
 
 ## Workflow 1: unique MCMC initialization points
 
 To seed ``N`` independent MCMC chains, we need ``N`` distinct starting points.
-`resample` with `replace=false` selects unique draws — at most one per candidate — using the
-stored PSIS weights, with no additional log-density evaluations.
+`resample` with `replace=false` selects unique draws using the stored PSIS weights, with no additional log-density evaluations.
 
 ```@example 1
-nchains = 4
+nchains = 8
 init_result = resample(result, nchains; replace=false)
 ```
+
+!!! note "Interpreting draws when sampling without replacement"
+    Sampling draws without replacement results in any estimates computed from those draws being biased.
+    As a result, one should probably only use these draws for initializing sampling algorithms.
 
 Each column of `init_result.draws` is a distinct point from the original candidate pool:
 
 ```@example 1
-init_result.draws
+length(unique(eachcol(init_result.draws))) / nchains
 ```
 
-The resampled result preserves the fitted distribution and all other fields, so it can be
-passed directly to any downstream Pathfinder-aware workflow:
+The resampled result preserves the fitted distribution and all other fields, so it can be passed directly to any downstream Pathfinder-aware workflow:
 
 ```@example 1
 init_result.fit_distribution === result.fit_distribution
@@ -59,27 +65,17 @@ init_result.fit_distribution === result.fit_distribution
 
 ## Workflow 2: more draws from the fitted distribution
 
-If the original run requested too few draws per run, we can generate fresh draws from the
-already-fitted mixture — avoiding a full Pathfinder re-run — and importance-resample them.
-The `ndraws_per_run` keyword controls how many fresh draws to sample from each mixture component
-before resampling.
+If the original run requested too few draws per run, we can generate fresh draws from the already-fitted mixture, avoiding re-running the optimization step, and optionally importance-resample them.
+The `ndraws_per_run` keyword controls how many fresh draws to sample from each mixture component before resampling.
 
 ```@example 1
 result2 = resample(result, 2_000; ndraws_per_run=200)
-size(result2.draws)
 ```
 
-The Pareto diagnostic for this new result reflects the quality of importance resampling over
-the fresh draws:
-
-```@example 1
-result2.psis_result.pareto_shape
-```
-
-To skip importance resampling entirely and draw directly from the mixture, pass
-`importance=false`:
+The Pareto diagnostic for this new result reflects the quality of importance resampling over the fresh draws.
+The importance-weighting step requires evaluating the provided log-density on all draws, which can be very expensive if the log-density itself is expensive.
+If you have strong evidence that Pathfinder's approximation is sufficiently close to your target distribution that you don't need importance reweighting or the Pareto ``k`` diagnostic, you may skip importance resampling entirely and draw directly from the fitted mixture distribution, pass `importance=false`:
 
 ```@example 1
 result3 = resample(result, 2_000; ndraws_per_run=200, importance=false)
-result3.psis_result === nothing
 ```

--- a/docs/src/examples/resampling.md
+++ b/docs/src/examples/resampling.md
@@ -1,0 +1,85 @@
+# Resampling from a fitted approximation
+
+After running [`multipathfinder`](@ref), the fitted mixture distribution and individual-run draws
+are stored in the result.
+[`resample`](@ref) lets you draw new samples from this approximation without re-running Pathfinder.
+Two common workflows are:
+
+1. **Selecting unique MCMC initialization points**: When the Pareto shape ``\hat{k}`` is large,
+   importance resampling *without replacement* yields at most one draw per unique candidate —
+   suitable as distinct starting points for independent MCMC chains.
+2. **Requesting more draws**: When the original run used too few `ndraws_per_run`, fresh draws
+   can be generated from the fitted mixture and importance-resampled, without re-fitting.
+
+## Setup
+
+We use the banana-shaped distribution from the [Quickstart](@ref) as our running example,
+since it has a poor Pareto-``\hat{k}`` diagnostic.
+
+```@example 1
+using Pathfinder, Random
+
+Random.seed!(23)
+
+logp_banana(x) = -(x[1]^2 + 5(x[2] - x[1]^2)^2) / 2
+
+result = multipathfinder(logp_banana, 200; dim=2, nruns=20, init_scale=10)
+```
+
+The large Pareto shape ``\hat{k}`` indicates that these draws are unreliable for computing
+posterior estimates, and we should run MCMC to get better samples.
+
+```@example 1
+result.psis_result.pareto_shape
+```
+
+## Workflow 1: unique MCMC initialization points
+
+To seed ``N`` independent MCMC chains, we need ``N`` distinct starting points.
+`resample` with `replace=false` selects unique draws — at most one per candidate — using the
+stored PSIS weights, with no additional log-density evaluations.
+
+```@example 1
+nchains = 4
+init_result = resample(result, nchains; replace=false)
+```
+
+Each column of `init_result.draws` is a distinct point from the original candidate pool:
+
+```@example 1
+init_result.draws
+```
+
+The resampled result preserves the fitted distribution and all other fields, so it can be
+passed directly to any downstream Pathfinder-aware workflow:
+
+```@example 1
+init_result.fit_distribution === result.fit_distribution
+```
+
+## Workflow 2: more draws from the fitted distribution
+
+If the original run requested too few draws per run, we can generate fresh draws from the
+already-fitted mixture — avoiding a full Pathfinder re-run — and importance-resample them.
+The `ndraws_per_run` keyword controls how many fresh draws to sample from each mixture component
+before resampling.
+
+```@example 1
+result2 = resample(result, 2_000; ndraws_per_run=200)
+size(result2.draws)
+```
+
+The Pareto diagnostic for this new result reflects the quality of importance resampling over
+the fresh draws:
+
+```@example 1
+result2.psis_result.pareto_shape
+```
+
+To skip importance resampling entirely and draw directly from the mixture, pass
+`importance=false`:
+
+```@example 1
+result3 = resample(result, 2_000; ndraws_per_run=200, importance=false)
+result3.psis_result === nothing
+```

--- a/docs/src/examples/turing.md
+++ b/docs/src/examples/turing.md
@@ -56,10 +56,11 @@ summarystats(chns_pf)
 ```
 
 We can also use these draws to initialize MCMC sampling with [`InitFromParams`](@extref `DynamicPPL.InitFromParams`).
-[`FlexiChains.VNChain`](@extref `FlexiChains.FlexiChain`) subsets iterations and chains with keyword arguments rather than [`MCMCChains.Chains`](@extref)'s 3-argument indexing; see the [FlexiChains migration guide](https://pysm.dev/FlexiChains.jl/stable/migration/) for more such translations.
+[`resample`](@ref) with `replace=false` selects `n_chains` distinct draws (importance-weighted) from the candidate pool; see [Resampling](@ref) for details.
 
 ```@example 1
-params = AbstractMCMC.to_samples(DynamicPPL.ParamsWithStats, chns_pf[iter=1:n_chains], model)
+init_result = resample(result_multi, n_chains; replace=false)
+params = AbstractMCMC.to_samples(DynamicPPL.ParamsWithStats, init_result.draws_transformed, model)
 initial_params = [InitFromParams(p.params) for p in vec(params)]
 nothing # hide
 ```
@@ -106,12 +107,12 @@ result_multi_mcmc = multipathfinder(
 chns_pf_mcmc = result_multi_mcmc.draws_transformed
 ```
 
-As before, we can use these draws to initialize MCMC sampling with [`InitFromParams`](@extref `DynamicPPL.InitFromParams`).
-Note that `Chains` subsets iterations and chains with 3-argument indexing (`chain[iterations, parameters, chains]`): 
+As before, we can use these draws to initialize MCMC sampling with [`InitFromParams`](@extref `DynamicPPL.InitFromParams`):
 
 ```@example 1
+init_result_mcmc = resample(result_multi_mcmc, n_chains; replace=false)
 params_mcmcchains = AbstractMCMC.to_samples(
-    DynamicPPL.ParamsWithStats, chns_pf_mcmc[1:n_chains, :, :], model
+    DynamicPPL.ParamsWithStats, init_result_mcmc.draws_transformed, model
 )
 initial_params_mcmcchains = [InitFromParams(p.params) for p in vec(params_mcmcchains)]
 nothing # hide

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -27,6 +27,16 @@ Public = true
 Private = false
 ```
 
+## Resampling
+
+```@autodocs
+Modules = [Pathfinder]
+Pages = ["resample.jl"]
+Order = [:function, :type]
+Public = true
+Private = false
+```
+
 ## Turing integration
 
 The above functions have special overloads for supporting Turing models.

--- a/ext/PathfinderTuringExt.jl
+++ b/ext/PathfinderTuringExt.jl
@@ -275,4 +275,11 @@ function Pathfinder.multipathfinder(
     return result_new
 end
 
+function Pathfinder._rebuild_draws_transformed(
+    model::DynamicPPL.Model, result, new_draws::AbstractMatrix
+)
+    ldf = create_log_density_function(model, Pathfinder.default_ad())
+    return draws_to_chains(typeof(result.draws_transformed), ldf, new_draws)
+end
+
 end  # module

--- a/ext/PathfinderTuringExt.jl
+++ b/ext/PathfinderTuringExt.jl
@@ -279,7 +279,7 @@ function Pathfinder._rebuild_draws_transformed(
     model::DynamicPPL.Model, result, new_draws::AbstractMatrix
 )
     ldf = create_log_density_function(model, Pathfinder.default_ad())
-    chain_type = Pathfinder._chain_constructor(result.draws_transformed)
+    chain_type = Pathfinder._chain_type_from_chain(result.draws_transformed)
     return draws_to_chains(chain_type, ldf, new_draws)
 end
 

--- a/ext/PathfinderTuringExt.jl
+++ b/ext/PathfinderTuringExt.jl
@@ -9,16 +9,18 @@ using Random: Random
 using Turing: Turing
 
 """
-    create_log_density_function(model::DynamicPPL.Model, adtype::ADTypes.AbstractADType)
+    create_log_density_function(model::DynamicPPL.Model, adtype)
 
 Create a log density function from a `model`.
 
 The return value is an object implementing the LogDensityProblems API whose log-density is
 that of the `model` transformed to unconstrained space with the appropriate log-density
-adjustment due to change of variables.
+adjustment due to change of variables. If `adtype` is `nothing`, only `logdensity` is
+implemented; if it is an `ADTypes.AbstractADType`, `logdensity_and_gradient` is also
+implemented.
 """
 function create_log_density_function(
-    model::DynamicPPL.Model, adtype::ADTypes.AbstractADType
+    model::DynamicPPL.Model, adtype::Union{ADTypes.AbstractADType,Nothing}
 )
     ldf = DynamicPPL.LogDensityFunction(
         model, DynamicPPL.getlogjoint_internal, DynamicPPL.LinkAll(); adtype
@@ -278,7 +280,7 @@ end
 function Pathfinder._rebuild_draws_transformed(
     model::DynamicPPL.Model, result, new_draws::AbstractMatrix
 )
-    ldf = create_log_density_function(model, Pathfinder.default_ad())
+    ldf = create_log_density_function(model, nothing)
     chain_type = Pathfinder._chain_type_from_chain(result.draws_transformed)
     return draws_to_chains(chain_type, ldf, new_draws)
 end

--- a/ext/PathfinderTuringExt.jl
+++ b/ext/PathfinderTuringExt.jl
@@ -279,7 +279,8 @@ function Pathfinder._rebuild_draws_transformed(
     model::DynamicPPL.Model, result, new_draws::AbstractMatrix
 )
     ldf = create_log_density_function(model, Pathfinder.default_ad())
-    return draws_to_chains(typeof(result.draws_transformed), ldf, new_draws)
+    chain_type = Pathfinder._chain_constructor(result.draws_transformed)
+    return draws_to_chains(chain_type, ldf, new_draws)
 end
 
 end  # module

--- a/ext/PathfinderTuringFlexiChainsExt.jl
+++ b/ext/PathfinderTuringFlexiChainsExt.jl
@@ -9,4 +9,6 @@ using Turing: Turing
     Pathfinder._default_turing_chain_type() = FlexiChains.VNChain
 end
 
+Pathfinder._chain_type_from_chain(chain::FlexiChains.VNChain) = typeof(chain)
+
 end  # module

--- a/ext/PathfinderTuringMCMCChainsExt.jl
+++ b/ext/PathfinderTuringMCMCChainsExt.jl
@@ -9,8 +9,8 @@ using Turing: Turing
     Pathfinder._default_turing_chain_type() = MCMCChains.Chains
 end
 
-# AbstractMCMC.from_samples for MCMCChains is only defined for the bare unparameterized type,
-# not for concrete subtypes, so return MCMCChains.Chains regardless of the concrete type.
-Pathfinder._chain_constructor(::MCMCChains.Chains) = MCMCChains.Chains
+# AbstractMCMC.from_samples for MCMCChains is only defined for the bare unparameterized
+# Chains type, not for concrete subtypes.
+Pathfinder._chain_type_from_chain(::MCMCChains.Chains) = MCMCChains.Chains
 
 end  # module

--- a/ext/PathfinderTuringMCMCChainsExt.jl
+++ b/ext/PathfinderTuringMCMCChainsExt.jl
@@ -9,4 +9,8 @@ using Turing: Turing
     Pathfinder._default_turing_chain_type() = MCMCChains.Chains
 end
 
+# AbstractMCMC.from_samples for MCMCChains is only defined for the bare unparameterized type,
+# not for concrete subtypes, so return MCMCChains.Chains regardless of the concrete type.
+Pathfinder._chain_constructor(::MCMCChains.Chains) = MCMCChains.Chains
+
 end  # module

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -20,7 +20,7 @@ using StatsBase: StatsBase
 
 # Declare and export the public API
 export PathfinderResult, MultiPathfinderResult
-export pathfinder, multipathfinder
+export pathfinder, multipathfinder, resample
 
 const DEFAULT_HISTORY_LENGTH = 6
 const DEFAULT_LINE_SEARCH = LineSearches.HagerZhang()
@@ -52,9 +52,9 @@ include("optimize.jl")
 include("inverse_hessian.jl")
 include("mvnormal.jl")
 include("elbo.jl")
-include("resample.jl")
 include("singlepath.jl")
 include("multipath.jl")
+include("resample.jl")
 
 function __init__()
     Requires.@require AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d" begin

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -226,9 +226,9 @@ function multipathfinder(
         )
         log_densities_target = _maybe_tmap(logp, eachcol(draws_all), ntasks)
         log_densities_ratios = log_densities_target - log_densities_fit
-        resample(rng, inds, log_densities_ratios, ndraws)
+        _resample(rng, inds, log_densities_ratios, ndraws)
     else
-        resample(rng, inds, ndraws), nothing
+        _resample(rng, inds, nothing, ndraws)
     end
 
     fit_distribution = Distributions.MixtureModel(fit_distributions)

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -146,7 +146,7 @@ function multipathfinder(
 )
     _init = if init === nothing
         nruns > 0 || throw(
-            ArgumentError("A positive `nruns` must be set or `init` must be provided.")
+            ArgumentError("A positive `nruns` must be set or `init` must be provided."),
         )
         fill(init, nruns)
     else
@@ -213,20 +213,17 @@ function multipathfinder(
         end
     end
     fit_distributions = map(x -> x.fit_distribution, pathfinder_results)
-    draws_all = mapreduce(x -> x.draws, hcat, pathfinder_results)
+    draws_all = reduce(hcat, map(x -> x.draws, pathfinder_results))
 
     # draw samples from augmented mixture model
     inds = axes(draws_all, 2)
     sample_inds, psis_result = if importance
-        log_densities_fit = _maybe_tmapreduce(
-            x -> Distributions.logpdf(x.fit_distribution, x.draws),
-            vcat,
-            pathfinder_results,
-            ntasks,
+        _resample(
+            rng,
+            inds,
+            _compute_log_densities_ratios(logp, pathfinder_results, draws_all, ntasks),
+            ndraws,
         )
-        log_densities_target = _maybe_tmap(logp, eachcol(draws_all), ntasks)
-        log_densities_ratios = log_densities_target - log_densities_fit
-        _resample(rng, inds, log_densities_ratios, ndraws)
     else
         _resample(rng, inds, nothing, ndraws)
     end

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -213,26 +213,16 @@ function multipathfinder(
         end
     end
     fit_distributions = map(x -> x.fit_distribution, pathfinder_results)
-    draws_all = reduce(hcat, map(x -> x.draws, pathfinder_results))
+    fit_distribution = Distributions.MixtureModel(fit_distributions)
+    draws_per_component = stack(map(x -> x.draws, pathfinder_results))
 
     # draw samples from augmented mixture model
-    inds = axes(draws_all, 2)
-    sample_inds, psis_result = if importance
-        _resample(
-            rng,
-            inds,
-            _compute_log_densities_ratios(logp, pathfinder_results, draws_all, ntasks),
-            ndraws,
-        )
+    psis_result = if importance
+        _compute_psis_result(logp, fit_distributions, draws_per_component; ntasks)
     else
-        _resample(rng, inds, nothing, ndraws)
+        nothing
     end
-
-    fit_distribution = Distributions.MixtureModel(fit_distributions)
-    draws = draws_all[:, sample_inds]
-
-    # get component ids (k) of draws in ϕ
-    draw_component_ids = cld.(sample_inds, ndraws_per_run)
+    draws, draw_component_ids = _resample(rng, draws_per_component, psis_result, ndraws)
 
     # placeholders
     fit_distribution_transformed = fit_distribution

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -19,101 +19,93 @@ All fields of the result are preserved except `draws`, `draw_component_ids`,
 """
 function resample(
     result::MultiPathfinderResult,
-    ndraws;
-    rng=result.rng,
-    replace=true,
-    importance=true,
-    ndraws_per_run=nothing,
-    ntasks=1,
+    ndraws::Int;
+    rng::Random.AbstractRNG=result.rng,
+    replace::Bool=true,
+    importance::Bool=true,
+    ndraws_per_run::Union{Nothing,Int}=nothing,
+    ntasks::Int=1,
 )
-    draws_all, eff_ndraws_per_run, psis_or_ratios = _get_candidate_draws(
-        rng, result, ndraws_per_run, importance, ntasks
+    draws_per_component, psis_result = _candidate_draws_and_psis_result(
+        rng, result, ndraws_per_run,
     )
-    sample_inds, new_psis = _resample(
-        rng, axes(draws_all, 2), psis_or_ratios, ndraws; replace
+    components = Distributions.components(result.fit_distribution)
+    psis_result_new = if importance
+        if psis_result === nothing
+            _compute_psis_result(result.logp, components, draws_per_component; ntasks)
+        else
+            psis_result
+        end
+    else
+        nothing
+    end
+    draws, draw_component_ids = _resample(
+        rng, draws_per_component, psis_result_new, ndraws; replace
     )
-    return _build_resampled_result(
-        result, draws_all, sample_inds, eff_ndraws_per_run, new_psis
-    )
+    return _build_resampled_result(result, draws, draw_component_ids, psis_result_new)
 end
 
 """
-    _resample(rng, x, log_weights, ndraws; replace=true) -> (draws, psis_result)
-    _resample(rng, x, psis_result::PSIS.PSISResult, ndraws; replace=true) -> (draws, psis_result)
-    _resample(rng, x, ::Nothing, ndraws; replace=true) -> (draws, nothing)
+    _resample(rng, x, psis_result, ndraws; replace=true) -> (draws, component_ids)
+    _resample(rng, x, ::Nothing, ndraws; replace=true) -> (draws, component_ids)
 
-Draw `ndraws` samples from `x`, returning `(samples, psis_result_or_nothing)`.
+Draw `ndraws` samples from the trailing axes of `x`, returning `draws`.
 
-- With `log_weights`: perform Pareto smoothed importance resampling.
-- With a `PSISResult`: reuse pre-computed PSIS weights.
+`x` is a 3D array with dimensions `(dim, ndraws_per_component, ncomponents)`.
+`draws` is a matrix with dimensions `(dim, ndraws)`.
+`component_ids` is an integer vector with dimensions `(ndraws,)`.
+
+- With a `PSIS.PSISResult`: sample with importance weights.
 - With `nothing`: sample uniformly.
 """
-function _resample(rng, x, log_ratios, ndraws; replace=true)
-    psis_result = PSIS.psis(log_ratios)
-    pweights = StatsBase.ProbabilityWeights(
-        psis_result.weights, one(eltype(psis_result.weights))
-    )
-    return StatsBase.sample(rng, x, pweights, ndraws; replace), psis_result
-end
-
-function _resample(rng, x, psis_result::PSIS.PSISResult, ndraws; replace=true)
-    pweights = StatsBase.ProbabilityWeights(
-        psis_result.weights, one(eltype(psis_result.weights))
-    )
-    return StatsBase.sample(rng, x, pweights, ndraws; replace), psis_result
-end
-
-function _resample(rng, x, ::Nothing, ndraws; replace=true)
-    return (StatsBase.sample(rng, x, ndraws; replace), nothing)
-end
-
-# Shared log-density ratio computation for importance resampling.
-# Returns log(p_target(x)) - log(q_component(x)) for each draw, where each draw x from
-# component k is evaluated against q_k (not the mixture), matching how multipathfinder
-# computes importance weights.
-function _compute_log_densities_ratios(logp, pathfinder_results, draws_all, ntasks)
-    log_densities_fit = _maybe_tmapreduce(
-        x -> Distributions.logpdf(x.fit_distribution, x.draws),
-        vcat,
-        pathfinder_results,
-        ntasks,
-    )
-    log_densities_target = _maybe_tmap(logp, eachcol(draws_all), ntasks)
-    return log_densities_target - log_densities_fit
-end
-
-# Use existing draws from pathfinder_results; reuse stored PSIS weights when available.
-function _get_candidate_draws(
-    rng, result::MultiPathfinderResult, ::Nothing, importance, ntasks
-)
-    draws_all = reduce(hcat, map(x -> x.draws, result.pathfinder_results))
-    eff_n = size(first(result.pathfinder_results).draws, 2)
-    if !importance
-        return draws_all, eff_n, nothing
-    elseif result.psis_result !== nothing
-        return draws_all, eff_n, result.psis_result  # reuse stored weights — no logp calls
+function _resample(rng, draws_per_component, psis_result, ndraws; replace=true)
+    draws_all = reshape(draws_per_component, size(draws_per_component, 1), :)
+    sample_inds = if psis_result === nothing
+        StatsBase.sample(rng, axes(draws_all, 2), ndraws; replace)
     else
-        return draws_all, eff_n, _compute_log_densities_ratios(
-            result.logp, result.pathfinder_results, draws_all, ntasks
+        pweights = StatsBase.ProbabilityWeights(
+            psis_result.weights, one(eltype(psis_result.weights))
         )
+        StatsBase.sample(rng, axes(draws_all, 2), pweights, ndraws; replace)
     end
+    draws = draws_all[:, sample_inds]
+    ndraws_per_component = size(draws_per_component, 2)
+    draw_component_ids = cld.(sample_inds, ndraws_per_component)
+    return draws, draw_component_ids
 end
 
-# Generate fresh draws from each mixture component using rand_and_logpdf for efficiency.
-function _get_candidate_draws(
-    rng, result::MultiPathfinderResult, ndraws_per_run::Int, importance, ntasks
+function _compute_psis_result(logp, components, draws_per_component; ntasks)
+    log_ratios = _compute_log_importance_ratios(
+        logp, components, draws_per_component, ntasks
+    )
+    return PSIS.psis(log_ratios)
+end
+
+function _compute_log_importance_ratios(logp, components, draws_per_component, ntasks)
+    log_densities_fit = stack(
+        _maybe_tmap(
+            Distributions.logpdf, components, eachslice(draws_per_component; dims=3); ntasks
+        ),
+    )
+    log_densities_target = _maybe_tmap(
+        logp, eachslice(draws_per_component; dims=(2, 3)); ntasks
+    )
+    log_ratios = vec(log_densities_target - log_densities_fit)
+    return log_ratios
+end
+
+function _candidate_draws_and_psis_result(_, result::MultiPathfinderResult, ::Nothing)
+    # Use existing draws
+    draws_per_component = stack(map(x -> x.draws, result.pathfinder_results))
+    return draws_per_component, result.psis_result
+end
+function _candidate_draws_and_psis_result(
+    rng, result::MultiPathfinderResult, ndraws_per_run::Int
 )
+    # Generate new draws from each mixture component
     components = Distributions.components(result.fit_distribution)
-    if importance
-        draws_and_logq = map(c -> rand_and_logpdf(rng, c, ndraws_per_run), components)
-        draws_all = reduce(hcat, map(first, draws_and_logq))
-        log_densities_fit = reduce(vcat, map(last, draws_and_logq))
-        log_densities_target = _maybe_tmap(result.logp, eachcol(draws_all), ntasks)
-        return draws_all, ndraws_per_run, log_densities_target - log_densities_fit
-    else
-        draws_all = reduce(hcat, map(c -> rand(rng, c, ndraws_per_run), components))
-        return draws_all, ndraws_per_run, nothing
-    end
+    draws_per_component = stack(map(c -> rand(rng, c, ndraws_per_run), components))
+    return draws_per_component, nothing
 end
 
 # Extension point for rebuilding draws_transformed after resampling.
@@ -125,11 +117,9 @@ function _chain_type_from_chain end
 
 # Applies sample_inds to draws_all and returns a new MultiPathfinderResult.
 function _build_resampled_result(
-    result::MultiPathfinderResult, draws_all, sample_inds, ndraws_per_run, new_psis_result
+    result::MultiPathfinderResult, draws, draw_component_ids, psis_result
 )
-    new_draws = draws_all[:, sample_inds]
-    new_draw_component_ids = cld.(sample_inds, ndraws_per_run)
-    new_draws_transformed = _rebuild_draws_transformed(result.input, result, new_draws)
+    draws_transformed = _rebuild_draws_transformed(result.input, result, draws)
     return MultiPathfinderResult(
         result.input,
         result.optimizer,
@@ -137,11 +127,11 @@ function _build_resampled_result(
         result.optim_fun,
         result.logp,
         result.fit_distribution,
-        new_draws,
-        new_draw_component_ids,
+        draws,
+        draw_component_ids,
         result.fit_distribution_transformed,
-        new_draws_transformed,
+        draws_transformed,
         result.pathfinder_results,
-        new_psis_result,
+        psis_result,
     )
 end

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -14,8 +14,8 @@ All fields of the result are preserved except `draws`, `draw_component_ids`,
     run from `fit_distribution` before resampling; otherwise reuse existing draws from
     `pathfinder_results`. Setting this is useful when more draws are needed than were
     originally requested.
-- `ntasks::Int=1`: number of parallel tasks for log-density evaluation, used only when
-    generating fresh draws with `importance=true`
+- `ntasks::Int=1`: number of parallel tasks for evaluating the target log density when
+    computing importance weights
 """
 function resample(
     result::MultiPathfinderResult,
@@ -47,16 +47,13 @@ end
 
 """
     _resample(rng, x, psis_result, ndraws; replace=true) -> (draws, component_ids)
-    _resample(rng, x, ::Nothing, ndraws; replace=true) -> (draws, component_ids)
 
-Draw `ndraws` samples from the trailing axes of `x`, returning `draws`.
+Draw `ndraws` samples from `x`, returning a draw matrix and component id vector.
 
-`x` is a 3D array with dimensions `(dim, ndraws_per_component, ncomponents)`.
-`draws` is a matrix with dimensions `(dim, ndraws)`.
-`component_ids` is an integer vector with dimensions `(ndraws,)`.
-
-- With a `PSIS.PSISResult`: sample with importance weights.
-- With `nothing`: sample uniformly.
+`x` is a 3D `(dim, ndraws_per_component, ncomponents)` array. The returned `draws` has
+size `(dim, ndraws)` and `component_ids` is an integer vector of length `ndraws`.
+If `psis_result` is a `PSIS.PSISResult`, samples are weighted by its importance weights;
+if `nothing`, samples are drawn uniformly.
 """
 function _resample(rng, draws_per_component, psis_result, ndraws; replace=true)
     draws_all = reshape(draws_per_component, size(draws_per_component, 1), :)

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -1,15 +1,116 @@
 """
-    resample(rng, x, log_weights, ndraws) -> (draws, psis_result)
-    resample(rng, x, ndraws) -> draws
+    resample(rng, x, log_weights, ndraws; replace=true) -> (draws, psis_result)
+    resample(rng, x, ndraws; replace=true) -> draws
 
-Draw `ndraws` samples from `x`, with replacement.
+Draw `ndraws` samples from `x`.
 
 If `log_weights` is provided, perform Pareto smoothed importance resampling.
 """
-function resample(rng, x, log_ratios, ndraws)
+function resample(rng, x, log_ratios, ndraws; replace=true)
     psis_result = PSIS.psis(log_ratios)
     (; weights) = psis_result
     pweights = StatsBase.ProbabilityWeights(weights, one(eltype(weights)))
-    return StatsBase.sample(rng, x, pweights, ndraws; replace=true), psis_result
+    return StatsBase.sample(rng, x, pweights, ndraws; replace), psis_result
 end
-resample(rng, x, ndraws) = StatsBase.sample(rng, x, ndraws; replace=true)
+resample(rng, x, ndraws; replace=true) = StatsBase.sample(rng, x, ndraws; replace)
+
+# Returns (draws_all, effective_ndraws_per_run).
+# When ndraws_per_run is nothing, uses existing draws stored in pathfinder_results.
+# When ndraws_per_run is an integer, generates fresh draws from each mixture component.
+function _get_candidate_draws(rng, result::MultiPathfinderResult, ndraws_per_run)
+    if ndraws_per_run === nothing
+        draws_all = mapreduce(x -> x.draws, hcat, result.pathfinder_results)
+        return draws_all, size(result.pathfinder_results[1].draws, 2)
+    else
+        components = Distributions.components(result.fit_distribution)
+        draws_all = mapreduce(c -> rand(rng, c, ndraws_per_run), hcat, components)
+        return draws_all, ndraws_per_run
+    end
+end
+
+# Computes log(p_target(x)) - log(q_fit(x)) for each column of draws_all.
+function _compute_log_densities_ratios(result::MultiPathfinderResult, draws_all, ntasks)
+    log_densities_fit = _maybe_tmap(
+        col -> Distributions.logpdf(result.fit_distribution, col),
+        eachcol(draws_all),
+        ntasks,
+    )
+    log_densities_target = _maybe_tmap(result.logp, eachcol(draws_all), ntasks)
+    return log_densities_target - log_densities_fit
+end
+
+# Extension point for rebuilding draws_transformed after resampling.
+# The Turing extension overrides this for DynamicPPL.Model inputs to return a Chains object.
+_rebuild_draws_transformed(input, result, new_draws) = new_draws
+
+# Applies sample_inds to draws_all and returns a new MultiPathfinderResult.
+function _build_resampled_result(
+    result::MultiPathfinderResult, draws_all, sample_inds, ndraws_per_run, new_psis_result
+)
+    new_draws = draws_all[:, sample_inds]
+    new_draw_component_ids = cld.(sample_inds, ndraws_per_run)
+    new_draws_transformed = _rebuild_draws_transformed(result.input, result, new_draws)
+    return MultiPathfinderResult(
+        result.input,
+        result.optimizer,
+        result.rng,
+        result.optim_fun,
+        result.logp,
+        result.fit_distribution,
+        new_draws,
+        new_draw_component_ids,
+        result.fit_distribution_transformed,
+        new_draws_transformed,
+        result.pathfinder_results,
+        new_psis_result,
+    )
+end
+
+"""
+    resample(result::MultiPathfinderResult, ndraws; kwargs...) -> MultiPathfinderResult
+
+Resample `ndraws` draws from a fitted [`MultiPathfinderResult`](@ref).
+
+All fields of the result are preserved except `draws`, `draw_component_ids`,
+`draws_transformed`, and `psis_result`, which reflect the new draws.
+
+# Keywords
+- `rng::AbstractRNG`: pseudorandom number generator (default: `result.rng`)
+- `replace::Bool=false`: sample with or without replacement
+- `importance::Bool=true`: use PSIS-smoothed importance weights
+- `ndraws_per_run::Union{Nothing,Int}=nothing`: if set, generate this many fresh draws per
+    run from `fit_distribution` before resampling; otherwise reuse existing draws from
+    `pathfinder_results`. Setting this is useful when more draws are needed than were
+    originally requested.
+- `ntasks::Int=1`: number of parallel tasks for log-density evaluation, used only when
+    generating fresh draws with `importance=true`
+"""
+function resample(
+    result::MultiPathfinderResult,
+    ndraws;
+    rng=result.rng,
+    replace=false,
+    importance=true,
+    ndraws_per_run=nothing,
+    ntasks=1,
+)
+    draws_all, eff_ndraws_per_run = _get_candidate_draws(rng, result, ndraws_per_run)
+
+    sample_inds, new_psis = if importance
+        if ndraws_per_run === nothing && result.psis_result !== nothing
+            # Reuse stored PSIS weights — avoids re-evaluating logp
+            pweights = StatsBase.ProbabilityWeights(
+                result.psis_result.weights, one(eltype(result.psis_result.weights))
+            )
+            StatsBase.sample(rng, axes(draws_all, 2), pweights, ndraws; replace),
+            result.psis_result
+        else
+            log_densities_ratios = _compute_log_densities_ratios(result, draws_all, ntasks)
+            resample(rng, axes(draws_all, 2), log_densities_ratios, ndraws; replace)
+        end
+    else
+        resample(rng, axes(draws_all, 2), ndraws; replace), nothing
+    end
+
+    return _build_resampled_result(result, draws_all, sample_inds, eff_ndraws_per_run, new_psis)
+end

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -1,18 +1,68 @@
 """
-    resample(rng, x, log_weights, ndraws; replace=true) -> (draws, psis_result)
-    resample(rng, x, ndraws; replace=true) -> draws
+    resample(result::MultiPathfinderResult, ndraws; kwargs...) -> MultiPathfinderResult
 
-Draw `ndraws` samples from `x`.
+Resample `ndraws` draws from a fitted [`MultiPathfinderResult`](@ref).
 
-If `log_weights` is provided, perform Pareto smoothed importance resampling.
+All fields of the result are preserved except `draws`, `draw_component_ids`,
+`draws_transformed`, and `psis_result`, which reflect the new draws.
+
+# Keywords
+- `rng::AbstractRNG`: pseudorandom number generator (default: `result.rng`)
+- `replace::Bool=true`: sample with or without replacement
+- `importance::Bool=true`: use PSIS-smoothed importance weights
+- `ndraws_per_run::Union{Nothing,Int}=nothing`: if set, generate this many fresh draws per
+    run from `fit_distribution` before resampling; otherwise reuse existing draws from
+    `pathfinder_results`. Setting this is useful when more draws are needed than were
+    originally requested.
+- `ntasks::Int=1`: number of parallel tasks for log-density evaluation, used only when
+    generating fresh draws with `importance=true`
 """
-function resample(rng, x, log_ratios, ndraws; replace=true)
+function resample(
+    result::MultiPathfinderResult,
+    ndraws;
+    rng=result.rng,
+    replace=true,
+    importance=true,
+    ndraws_per_run=nothing,
+    ntasks=1,
+)
+    draws_all, eff_ndraws_per_run = _get_candidate_draws(rng, result, ndraws_per_run)
+
+    psis_or_ratios = if !importance
+        nothing
+    elseif ndraws_per_run === nothing && result.psis_result !== nothing
+        result.psis_result  # reuse stored weights — avoids re-evaluating logp
+    else
+        _compute_log_densities_ratios(result, draws_all, ntasks)
+    end
+
+    sample_inds, new_psis = _resample(rng, axes(draws_all, 2), psis_or_ratios, ndraws; replace)
+    return _build_resampled_result(result, draws_all, sample_inds, eff_ndraws_per_run, new_psis)
+end
+
+"""
+    _resample(rng, x, log_weights, ndraws; replace=true) -> (draws, psis_result)
+    _resample(rng, x, psis_result::PSIS.PSISResult, ndraws; replace=true) -> (draws, psis_result)
+    _resample(rng, x, ::Nothing, ndraws; replace=true) -> (draws, nothing)
+
+Draw `ndraws` samples from `x`, returning `(samples, psis_result_or_nothing)`.
+
+- With `log_weights`: perform Pareto smoothed importance resampling.
+- With a `PSISResult`: reuse pre-computed PSIS weights.
+- With `nothing`: sample uniformly.
+"""
+function _resample(rng, x, log_ratios, ndraws; replace=true)
     psis_result = PSIS.psis(log_ratios)
-    (; weights) = psis_result
-    pweights = StatsBase.ProbabilityWeights(weights, one(eltype(weights)))
+    pweights = StatsBase.ProbabilityWeights(psis_result.weights, one(eltype(psis_result.weights)))
     return StatsBase.sample(rng, x, pweights, ndraws; replace), psis_result
 end
-resample(rng, x, ndraws; replace=true) = StatsBase.sample(rng, x, ndraws; replace)
+
+function _resample(rng, x, psis_result::PSIS.PSISResult, ndraws; replace=true)
+    pweights = StatsBase.ProbabilityWeights(psis_result.weights, one(eltype(psis_result.weights)))
+    return StatsBase.sample(rng, x, pweights, ndraws; replace), psis_result
+end
+
+_resample(rng, x, ::Nothing, ndraws; replace=true) = (StatsBase.sample(rng, x, ndraws; replace), nothing)
 
 # Returns (draws_all, effective_ndraws_per_run).
 # When ndraws_per_run is nothing, uses existing draws stored in pathfinder_results.
@@ -64,53 +114,4 @@ function _build_resampled_result(
         result.pathfinder_results,
         new_psis_result,
     )
-end
-
-"""
-    resample(result::MultiPathfinderResult, ndraws; kwargs...) -> MultiPathfinderResult
-
-Resample `ndraws` draws from a fitted [`MultiPathfinderResult`](@ref).
-
-All fields of the result are preserved except `draws`, `draw_component_ids`,
-`draws_transformed`, and `psis_result`, which reflect the new draws.
-
-# Keywords
-- `rng::AbstractRNG`: pseudorandom number generator (default: `result.rng`)
-- `replace::Bool=false`: sample with or without replacement
-- `importance::Bool=true`: use PSIS-smoothed importance weights
-- `ndraws_per_run::Union{Nothing,Int}=nothing`: if set, generate this many fresh draws per
-    run from `fit_distribution` before resampling; otherwise reuse existing draws from
-    `pathfinder_results`. Setting this is useful when more draws are needed than were
-    originally requested.
-- `ntasks::Int=1`: number of parallel tasks for log-density evaluation, used only when
-    generating fresh draws with `importance=true`
-"""
-function resample(
-    result::MultiPathfinderResult,
-    ndraws;
-    rng=result.rng,
-    replace=false,
-    importance=true,
-    ndraws_per_run=nothing,
-    ntasks=1,
-)
-    draws_all, eff_ndraws_per_run = _get_candidate_draws(rng, result, ndraws_per_run)
-
-    sample_inds, new_psis = if importance
-        if ndraws_per_run === nothing && result.psis_result !== nothing
-            # Reuse stored PSIS weights — avoids re-evaluating logp
-            pweights = StatsBase.ProbabilityWeights(
-                result.psis_result.weights, one(eltype(result.psis_result.weights))
-            )
-            StatsBase.sample(rng, axes(draws_all, 2), pweights, ndraws; replace),
-            result.psis_result
-        else
-            log_densities_ratios = _compute_log_densities_ratios(result, draws_all, ntasks)
-            resample(rng, axes(draws_all, 2), log_densities_ratios, ndraws; replace)
-        end
-    else
-        resample(rng, axes(draws_all, 2), ndraws; replace), nothing
-    end
-
-    return _build_resampled_result(result, draws_all, sample_inds, eff_ndraws_per_run, new_psis)
 end

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -67,57 +67,60 @@ function _resample(rng, x, ::Nothing, ndraws; replace=true)
     return (StatsBase.sample(rng, x, ndraws; replace), nothing)
 end
 
-# Returns (draws_all, effective_ndraws_per_run, psis_or_ratios).
-# When ndraws_per_run is nothing, reuses existing draws stored in pathfinder_results,
-# along with stored PSIS weights if available. When ndraws_per_run is an integer, generates
-# fresh draws from each mixture component using rand_and_logpdf for efficiency.
-# psis_or_ratios is PSISResult (reuse stored), AbstractVector (log-ratios to smooth), or nothing.
+# Shared log-density ratio computation for importance resampling.
+# Returns log(p_target(x)) - log(q_component(x)) for each draw, where each draw x from
+# component k is evaluated against q_k (not the mixture), matching how multipathfinder
+# computes importance weights.
+function _compute_log_densities_ratios(logp, pathfinder_results, draws_all, ntasks)
+    log_densities_fit = _maybe_tmapreduce(
+        x -> Distributions.logpdf(x.fit_distribution, x.draws),
+        vcat,
+        pathfinder_results,
+        ntasks,
+    )
+    log_densities_target = _maybe_tmap(logp, eachcol(draws_all), ntasks)
+    return log_densities_target - log_densities_fit
+end
+
+# Use existing draws from pathfinder_results; reuse stored PSIS weights when available.
 function _get_candidate_draws(
-    rng, result::MultiPathfinderResult, ndraws_per_run, importance, ntasks
+    rng, result::MultiPathfinderResult, ::Nothing, importance, ntasks
 )
-    if ndraws_per_run === nothing
-        draws_all = reduce(hcat, map(x -> x.draws, result.pathfinder_results))
-        eff_n = size(first(result.pathfinder_results).draws, 2)
-        if !importance
-            return draws_all, eff_n, nothing
-        elseif result.psis_result !== nothing
-            return draws_all, eff_n, result.psis_result  # reuse stored weights — no logp calls
-        else
-            # Use each component's log-density, not the mixture's, matching how
-            # multipathfinder computes importance weights.
-            log_densities_fit = _maybe_tmapreduce(
-                x -> Distributions.logpdf(x.fit_distribution, x.draws),
-                vcat,
-                result.pathfinder_results,
-                ntasks,
-            )
-            log_densities_target = _maybe_tmap(result.logp, eachcol(draws_all), ntasks)
-            return draws_all, eff_n, log_densities_target - log_densities_fit
-        end
+    draws_all = reduce(hcat, map(x -> x.draws, result.pathfinder_results))
+    eff_n = size(first(result.pathfinder_results).draws, 2)
+    if !importance
+        return draws_all, eff_n, nothing
+    elseif result.psis_result !== nothing
+        return draws_all, eff_n, result.psis_result  # reuse stored weights — no logp calls
     else
-        components = Distributions.components(result.fit_distribution)
-        if importance
-            # rand_and_logpdf generates draws and their log-densities together
-            draws_and_logq = map(c -> rand_and_logpdf(rng, c, ndraws_per_run), components)
-            draws_all = reduce(hcat, map(first, draws_and_logq))
-            log_densities_fit = reduce(vcat, map(last, draws_and_logq))
-            log_densities_target = _maybe_tmap(result.logp, eachcol(draws_all), ntasks)
-            return draws_all, ndraws_per_run, log_densities_target - log_densities_fit
-        else
-            draws_all = reduce(hcat, map(c -> rand(rng, c, ndraws_per_run), components))
-            return draws_all, ndraws_per_run, nothing
-        end
+        return draws_all, eff_n, _compute_log_densities_ratios(
+            result.logp, result.pathfinder_results, draws_all, ntasks
+        )
+    end
+end
+
+# Generate fresh draws from each mixture component using rand_and_logpdf for efficiency.
+function _get_candidate_draws(
+    rng, result::MultiPathfinderResult, ndraws_per_run::Int, importance, ntasks
+)
+    components = Distributions.components(result.fit_distribution)
+    if importance
+        draws_and_logq = map(c -> rand_and_logpdf(rng, c, ndraws_per_run), components)
+        draws_all = reduce(hcat, map(first, draws_and_logq))
+        log_densities_fit = reduce(vcat, map(last, draws_and_logq))
+        log_densities_target = _maybe_tmap(result.logp, eachcol(draws_all), ntasks)
+        return draws_all, ndraws_per_run, log_densities_target - log_densities_fit
+    else
+        draws_all = reduce(hcat, map(c -> rand(rng, c, ndraws_per_run), components))
+        return draws_all, ndraws_per_run, nothing
     end
 end
 
 # Extension point for rebuilding draws_transformed after resampling.
-# The Turing extension overrides this for DynamicPPL.Model inputs to return a Chains object.
 _rebuild_draws_transformed(input, result, new_draws) = new_draws
 
 # Extension point: return the chain type to pass to AbstractMCMC.from_samples.
 # Chain-type-specific extensions override this so that from_samples dispatches correctly.
-# For example, MCMCChains defines from_samples only for the bare unparameterized type, so
-# its override returns MCMCChains.Chains rather than the concrete parameterized type.
 function _chain_type_from_chain end
 
 # Applies sample_inds to draws_all and returns a new MultiPathfinderResult.
@@ -125,10 +128,7 @@ function _build_resampled_result(
     result::MultiPathfinderResult, draws_all, sample_inds, ndraws_per_run, new_psis_result
 )
     new_draws = draws_all[:, sample_inds]
-    nruns = length(result.pathfinder_results)
-    draw_component_ids_all = repeat(1:nruns; inner=ndraws_per_run)
-    col_offset = firstindex(draws_all, 2) - 1
-    new_draw_component_ids = draw_component_ids_all[sample_inds .- col_offset]
+    new_draw_component_ids = cld.(sample_inds, ndraws_per_run)
     new_draws_transformed = _rebuild_draws_transformed(result.input, result, new_draws)
     return MultiPathfinderResult(
         result.input,

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -93,6 +93,12 @@ end
 # The Turing extension overrides this for DynamicPPL.Model inputs to return a Chains object.
 _rebuild_draws_transformed(input, result, new_draws) = new_draws
 
+# Extension point: return the chain constructor to pass to AbstractMCMC.from_samples.
+# Chain-type-specific extensions override this so that from_samples dispatches correctly.
+# For example, MCMCChains defines from_samples only for the bare unparameterized type, so
+# its override returns MCMCChains.Chains rather than the concrete parameterized type.
+_chain_constructor(chain) = typeof(chain)
+
 # Applies sample_inds to draws_all and returns a new MultiPathfinderResult.
 function _build_resampled_result(
     result::MultiPathfinderResult, draws_all, sample_inds, ndraws_per_run, new_psis_result

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -27,7 +27,7 @@ function resample(
     ntasks::Int=1,
 )
     draws_per_component, psis_result = _candidate_draws_and_psis_result(
-        rng, result, ndraws_per_run,
+        rng, result, ndraws_per_run
     )
     components = Distributions.components(result.fit_distribution)
     psis_result_new = if importance

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -29,9 +29,9 @@ function resample(
     draws_per_component, psis_result = _candidate_draws_and_psis_result(
         rng, result, ndraws_per_run
     )
-    components = Distributions.components(result.fit_distribution)
     psis_result_new = if importance
         if psis_result === nothing
+            components = Distributions.components(result.fit_distribution)
             _compute_psis_result(result.logp, components, draws_per_component; ntasks)
         else
             psis_result

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -79,6 +79,9 @@ function _compute_psis_result(logp, components, draws_per_component; ntasks)
 end
 
 function _compute_log_importance_ratios(logp, components, draws_per_component, ntasks)
+    # Both eachslice calls return AbstractArrays whose size matches the sliced dimensions
+    # — (K,) and (N, K) — and _maybe_tmap (like map) preserves that size, so both
+    # log_densities_fit and log_densities_target are (N, K) and subtract element-wise.
     log_densities_fit = stack(
         _maybe_tmap(
             Distributions.logpdf, components, eachslice(draws_per_component; dims=3); ntasks

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -29,8 +29,12 @@ function resample(
     draws_all, eff_ndraws_per_run, psis_or_ratios = _get_candidate_draws(
         rng, result, ndraws_per_run, importance, ntasks
     )
-    sample_inds, new_psis = _resample(rng, axes(draws_all, 2), psis_or_ratios, ndraws; replace)
-    return _build_resampled_result(result, draws_all, sample_inds, eff_ndraws_per_run, new_psis)
+    sample_inds, new_psis = _resample(
+        rng, axes(draws_all, 2), psis_or_ratios, ndraws; replace
+    )
+    return _build_resampled_result(
+        result, draws_all, sample_inds, eff_ndraws_per_run, new_psis
+    )
 end
 
 """
@@ -46,23 +50,31 @@ Draw `ndraws` samples from `x`, returning `(samples, psis_result_or_nothing)`.
 """
 function _resample(rng, x, log_ratios, ndraws; replace=true)
     psis_result = PSIS.psis(log_ratios)
-    pweights = StatsBase.ProbabilityWeights(psis_result.weights, one(eltype(psis_result.weights)))
+    pweights = StatsBase.ProbabilityWeights(
+        psis_result.weights, one(eltype(psis_result.weights))
+    )
     return StatsBase.sample(rng, x, pweights, ndraws; replace), psis_result
 end
 
 function _resample(rng, x, psis_result::PSIS.PSISResult, ndraws; replace=true)
-    pweights = StatsBase.ProbabilityWeights(psis_result.weights, one(eltype(psis_result.weights)))
+    pweights = StatsBase.ProbabilityWeights(
+        psis_result.weights, one(eltype(psis_result.weights))
+    )
     return StatsBase.sample(rng, x, pweights, ndraws; replace), psis_result
 end
 
-_resample(rng, x, ::Nothing, ndraws; replace=true) = (StatsBase.sample(rng, x, ndraws; replace), nothing)
+function _resample(rng, x, ::Nothing, ndraws; replace=true)
+    return (StatsBase.sample(rng, x, ndraws; replace), nothing)
+end
 
 # Returns (draws_all, effective_ndraws_per_run, psis_or_ratios).
 # When ndraws_per_run is nothing, reuses existing draws stored in pathfinder_results,
 # along with stored PSIS weights if available. When ndraws_per_run is an integer, generates
 # fresh draws from each mixture component using rand_and_logpdf for efficiency.
 # psis_or_ratios is PSISResult (reuse stored), AbstractVector (log-ratios to smooth), or nothing.
-function _get_candidate_draws(rng, result::MultiPathfinderResult, ndraws_per_run, importance, ntasks)
+function _get_candidate_draws(
+    rng, result::MultiPathfinderResult, ndraws_per_run, importance, ntasks
+)
     if ndraws_per_run === nothing
         draws_all = reduce(hcat, map(x -> x.draws, result.pathfinder_results))
         eff_n = size(first(result.pathfinder_results).draws, 2)

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -26,16 +26,9 @@ function resample(
     ndraws_per_run=nothing,
     ntasks=1,
 )
-    draws_all, eff_ndraws_per_run = _get_candidate_draws(rng, result, ndraws_per_run)
-
-    psis_or_ratios = if !importance
-        nothing
-    elseif ndraws_per_run === nothing && result.psis_result !== nothing
-        result.psis_result  # reuse stored weights — avoids re-evaluating logp
-    else
-        _compute_log_densities_ratios(result, draws_all, ntasks)
-    end
-
+    draws_all, eff_ndraws_per_run, psis_or_ratios = _get_candidate_draws(
+        rng, result, ndraws_per_run, importance, ntasks
+    )
     sample_inds, new_psis = _resample(rng, axes(draws_all, 2), psis_or_ratios, ndraws; replace)
     return _build_resampled_result(result, draws_all, sample_inds, eff_ndraws_per_run, new_psis)
 end
@@ -64,47 +57,66 @@ end
 
 _resample(rng, x, ::Nothing, ndraws; replace=true) = (StatsBase.sample(rng, x, ndraws; replace), nothing)
 
-# Returns (draws_all, effective_ndraws_per_run).
-# When ndraws_per_run is nothing, uses existing draws stored in pathfinder_results.
-# When ndraws_per_run is an integer, generates fresh draws from each mixture component.
-function _get_candidate_draws(rng, result::MultiPathfinderResult, ndraws_per_run)
+# Returns (draws_all, effective_ndraws_per_run, psis_or_ratios).
+# When ndraws_per_run is nothing, reuses existing draws stored in pathfinder_results,
+# along with stored PSIS weights if available. When ndraws_per_run is an integer, generates
+# fresh draws from each mixture component using rand_and_logpdf for efficiency.
+# psis_or_ratios is PSISResult (reuse stored), AbstractVector (log-ratios to smooth), or nothing.
+function _get_candidate_draws(rng, result::MultiPathfinderResult, ndraws_per_run, importance, ntasks)
     if ndraws_per_run === nothing
-        draws_all = mapreduce(x -> x.draws, hcat, result.pathfinder_results)
-        return draws_all, size(result.pathfinder_results[1].draws, 2)
+        draws_all = reduce(hcat, map(x -> x.draws, result.pathfinder_results))
+        eff_n = size(first(result.pathfinder_results).draws, 2)
+        if !importance
+            return draws_all, eff_n, nothing
+        elseif result.psis_result !== nothing
+            return draws_all, eff_n, result.psis_result  # reuse stored weights — no logp calls
+        else
+            # Use each component's log-density, not the mixture's, matching how
+            # multipathfinder computes importance weights.
+            log_densities_fit = _maybe_tmapreduce(
+                x -> Distributions.logpdf(x.fit_distribution, x.draws),
+                vcat,
+                result.pathfinder_results,
+                ntasks,
+            )
+            log_densities_target = _maybe_tmap(result.logp, eachcol(draws_all), ntasks)
+            return draws_all, eff_n, log_densities_target - log_densities_fit
+        end
     else
         components = Distributions.components(result.fit_distribution)
-        draws_all = mapreduce(c -> rand(rng, c, ndraws_per_run), hcat, components)
-        return draws_all, ndraws_per_run
+        if importance
+            # rand_and_logpdf generates draws and their log-densities together
+            draws_and_logq = map(c -> rand_and_logpdf(rng, c, ndraws_per_run), components)
+            draws_all = reduce(hcat, map(first, draws_and_logq))
+            log_densities_fit = reduce(vcat, map(last, draws_and_logq))
+            log_densities_target = _maybe_tmap(result.logp, eachcol(draws_all), ntasks)
+            return draws_all, ndraws_per_run, log_densities_target - log_densities_fit
+        else
+            draws_all = reduce(hcat, map(c -> rand(rng, c, ndraws_per_run), components))
+            return draws_all, ndraws_per_run, nothing
+        end
     end
-end
-
-# Computes log(p_target(x)) - log(q_fit(x)) for each column of draws_all.
-function _compute_log_densities_ratios(result::MultiPathfinderResult, draws_all, ntasks)
-    log_densities_fit = _maybe_tmap(
-        col -> Distributions.logpdf(result.fit_distribution, col),
-        eachcol(draws_all),
-        ntasks,
-    )
-    log_densities_target = _maybe_tmap(result.logp, eachcol(draws_all), ntasks)
-    return log_densities_target - log_densities_fit
 end
 
 # Extension point for rebuilding draws_transformed after resampling.
 # The Turing extension overrides this for DynamicPPL.Model inputs to return a Chains object.
 _rebuild_draws_transformed(input, result, new_draws) = new_draws
 
-# Extension point: return the chain constructor to pass to AbstractMCMC.from_samples.
+# Extension point: return the chain type to pass to AbstractMCMC.from_samples.
 # Chain-type-specific extensions override this so that from_samples dispatches correctly.
 # For example, MCMCChains defines from_samples only for the bare unparameterized type, so
 # its override returns MCMCChains.Chains rather than the concrete parameterized type.
-_chain_constructor(chain) = typeof(chain)
+function _chain_type_from_chain end
 
 # Applies sample_inds to draws_all and returns a new MultiPathfinderResult.
 function _build_resampled_result(
     result::MultiPathfinderResult, draws_all, sample_inds, ndraws_per_run, new_psis_result
 )
     new_draws = draws_all[:, sample_inds]
-    new_draw_component_ids = cld.(sample_inds, ndraws_per_run)
+    nruns = length(result.pathfinder_results)
+    draw_component_ids_all = repeat(1:nruns; inner=ndraws_per_run)
+    col_offset = firstindex(draws_all, 2) - 1
+    new_draw_component_ids = draw_component_ids_all[sample_inds .- col_offset]
     new_draws_transformed = _rebuild_draws_transformed(result.input, result, new_draws)
     return MultiPathfinderResult(
         result.input,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,21 +30,21 @@ function _chunk_tmap(f, xss::AbstractArray...; ntasks::Int, setup)
 end
 
 # `map`/`mapreduce` using at most `ntasks` parallel tasks.
-function _maybe_tmap(f, xs::AbstractArray, ntasks::Int)
-    nchunks = _nchunks(length(xs), ntasks)
+function _maybe_tmap(f, xss::AbstractArray...; ntasks::Int)
+    nchunks = _nchunks(length(first(xss)), ntasks)
     if nchunks == 1
-        return map(f, xs)
+        return map(f, xss...)
     else
-        return OhMyThreads.tmap(f, xs; nchunks)
+        return OhMyThreads.tmap(f, xss...; nchunks)
     end
 end
 
-function _maybe_tmapreduce(f, op, xs::AbstractArray, ntasks::Int)
-    nchunks = _nchunks(length(xs), ntasks)
+function _maybe_tmapreduce(f, op, xss::AbstractArray...; ntasks::Int)
+    nchunks = _nchunks(length(first(xss)), ntasks)
     if nchunks == 1
-        return mapreduce(f, op, xs)
+        return mapreduce(f, op, xss...)
     else
-        return OhMyThreads.tmapreduce(f, op, xs; nchunks)
+        return OhMyThreads.tmapreduce(f, op, xss...; nchunks)
     end
 end
 

--- a/test/integration/Turing/runtests.jl
+++ b/test/integration/Turing/runtests.jl
@@ -223,6 +223,22 @@ end
         end
     end
 
+    @testset "resample(::MultiPathfinderResult)" begin
+        model = dynamic_const_model()
+        result = multipathfinder(model, 20; nruns=4, chain_type=MCMCChains.Chains)
+        r2 = resample(result, 5; replace=false)
+        @test r2 isa MultiPathfinderResult
+        @test r2.draws_transformed isa MCMCChains.Chains
+        @test size(r2.draws, 2) == 5
+        @test_throws MethodError Pathfinder._chain_type_from_chain(r2.draws)
+
+        result_flexi = multipathfinder(model, 20; nruns=4, chain_type=FlexiChains.VNChain)
+        r3 = resample(result_flexi, 5; replace=false)
+        @test r3 isa MultiPathfinderResult
+        @test r3.draws_transformed isa FlexiChains.VNChain
+        @test size(r3.draws, 2) == 5
+    end
+
     @testset "AbstractInitStrategy integration" begin
         x = 0:0.01:1
         y = sin.(x) .+ randn.() .* 0.2 .+ x

--- a/test/multipath.jl
+++ b/test/multipath.jl
@@ -121,10 +121,8 @@ using Test
             )
             @test serial.draws == threaded.draws
             @test serial.draw_component_ids == threaded.draw_component_ids
-            @test [c.μ for c in serial.fit_distribution.components] ==
-                [c.μ for c in threaded.fit_distribution.components]
-            @test [c.Σ for c in serial.fit_distribution.components] ==
-                [c.Σ for c in threaded.fit_distribution.components]
+            @test [c.μ for c in serial.fit_distribution.components] == [c.μ for c in threaded.fit_distribution.components]
+            @test [c.Σ for c in serial.fit_distribution.components] == [c.Σ for c in threaded.fit_distribution.components]
         end
 
         @testset "default rng" begin
@@ -136,10 +134,8 @@ using Test
             )
             @test serial.draws == threaded.draws
             @test serial.draw_component_ids == threaded.draw_component_ids
-            @test [c.μ for c in serial.fit_distribution.components] ==
-                [c.μ for c in threaded.fit_distribution.components]
-            @test [c.Σ for c in serial.fit_distribution.components] ==
-                [c.Σ for c in threaded.fit_distribution.components]
+            @test [c.μ for c in serial.fit_distribution.components] == [c.μ for c in threaded.fit_distribution.components]
+            @test [c.Σ for c in serial.fit_distribution.components] == [c.Σ for c in threaded.fit_distribution.components]
         end
     end
 
@@ -187,6 +183,18 @@ using Test
             end
         end
 
+        @testset "resample existing draws with importance, no stored PSIS" begin
+            result_no_psis = multipathfinder(ℓ, ndraws_per_run; nruns, ndraws_per_run, rng, importance=false)
+            @test result_no_psis.psis_result === nothing
+            r2 = resample(result_no_psis, ndraws_new)
+            @test r2 isa MultiPathfinderResult
+            @test r2.psis_result isa PSIS.PSISResult
+            draws_all = mapreduce(x -> x.draws, hcat, result_no_psis.pathfinder_results)
+            for col in eachcol(r2.draws)
+                @test any(==(col), eachcol(draws_all))
+            end
+        end
+
         @testset "generate new draws" begin
             r2 = resample(result, ndraws_new; ndraws_per_run=50, replace=true)
             @test r2 isa MultiPathfinderResult
@@ -197,7 +205,9 @@ using Test
         end
 
         @testset "generate new draws without importance" begin
-            r2 = resample(result, ndraws_new; ndraws_per_run=50, importance=false, replace=true)
+            r2 = resample(
+                result, ndraws_new; ndraws_per_run=50, importance=false, replace=true
+            )
             @test size(r2.draws) == (dim, ndraws_new)
             @test r2.psis_result === nothing
         end

--- a/test/multipath.jl
+++ b/test/multipath.jl
@@ -154,7 +154,7 @@ using Test
         rng = MersenneTwister(42)
         result = multipathfinder(ℓ, ndraws_per_run; nruns, ndraws_per_run, rng)
 
-        @testset "resample existing draws without replacement" begin
+        @testset "resample existing draws with replacement" begin
             r2 = resample(result, ndraws_new)
             @test r2 isa MultiPathfinderResult
             @test size(r2.draws) == (dim, ndraws_new)
@@ -162,22 +162,20 @@ using Test
             @test length(unique(r2.draw_component_ids)) <= nruns
             @test r2.draws_transformed == r2.draws
             @test r2.psis_result === result.psis_result
-            # all draws come from original candidate pool
             draws_all = mapreduce(x -> x.draws, hcat, result.pathfinder_results)
             for col in eachcol(r2.draws)
                 @test any(==(col), eachcol(draws_all))
             end
-            # without replacement: no duplicate columns
-            @test length(unique(eachcol(r2.draws))) == ndraws_new
         end
 
-        @testset "resample existing draws with replacement" begin
-            r2 = resample(result, ndraws_new; replace=true)
+        @testset "resample existing draws without replacement" begin
+            r2 = resample(result, ndraws_new; replace=false)
             @test size(r2.draws) == (dim, ndraws_new)
             draws_all = mapreduce(x -> x.draws, hcat, result.pathfinder_results)
             for col in eachcol(r2.draws)
                 @test any(==(col), eachcol(draws_all))
             end
+            @test length(unique(eachcol(r2.draws))) == ndraws_new
         end
 
         @testset "resample existing draws without importance" begin

--- a/test/multipath.jl
+++ b/test/multipath.jl
@@ -184,7 +184,9 @@ using Test
         end
 
         @testset "resample existing draws with importance, no stored PSIS" begin
-            result_no_psis = multipathfinder(ℓ, ndraws_per_run; nruns, ndraws_per_run, rng, importance=false)
+            result_no_psis = multipathfinder(
+                ℓ, ndraws_per_run; nruns, ndraws_per_run, rng, importance=false
+            )
             @test result_no_psis.psis_result === nothing
             r2 = resample(result_no_psis, ndraws_new)
             @test r2 isa MultiPathfinderResult

--- a/test/multipath.jl
+++ b/test/multipath.jl
@@ -142,4 +142,82 @@ using Test
                 [c.Σ for c in threaded.fit_distribution.components]
         end
     end
+
+    @testset "resample(::MultiPathfinderResult)" begin
+        dim = 5
+        nruns = 4
+        ndraws_per_run = 20
+        ndraws_total = nruns * ndraws_per_run
+        ndraws_new = 8
+        logp(x) = -sum(abs2, x) / 2
+        ℓ = build_logdensityproblem(logp, dim, 2)
+        rng = MersenneTwister(42)
+        result = multipathfinder(ℓ, ndraws_per_run; nruns, ndraws_per_run, rng)
+
+        @testset "resample existing draws without replacement" begin
+            r2 = resample(result, ndraws_new)
+            @test r2 isa MultiPathfinderResult
+            @test size(r2.draws) == (dim, ndraws_new)
+            @test length(r2.draw_component_ids) == ndraws_new
+            @test length(unique(r2.draw_component_ids)) <= nruns
+            @test r2.draws_transformed == r2.draws
+            @test r2.psis_result === result.psis_result
+            # all draws come from original candidate pool
+            draws_all = mapreduce(x -> x.draws, hcat, result.pathfinder_results)
+            for col in eachcol(r2.draws)
+                @test any(==(col), eachcol(draws_all))
+            end
+            # without replacement: no duplicate columns
+            @test length(unique(eachcol(r2.draws))) == ndraws_new
+        end
+
+        @testset "resample existing draws with replacement" begin
+            r2 = resample(result, ndraws_new; replace=true)
+            @test size(r2.draws) == (dim, ndraws_new)
+            draws_all = mapreduce(x -> x.draws, hcat, result.pathfinder_results)
+            for col in eachcol(r2.draws)
+                @test any(==(col), eachcol(draws_all))
+            end
+        end
+
+        @testset "resample existing draws without importance" begin
+            r2 = resample(result, ndraws_new; importance=false)
+            @test r2.psis_result === nothing
+            draws_all = mapreduce(x -> x.draws, hcat, result.pathfinder_results)
+            for col in eachcol(r2.draws)
+                @test any(==(col), eachcol(draws_all))
+            end
+        end
+
+        @testset "generate new draws" begin
+            r2 = resample(result, ndraws_new; ndraws_per_run=50, replace=true)
+            @test r2 isa MultiPathfinderResult
+            @test size(r2.draws) == (dim, ndraws_new)
+            @test length(r2.draw_component_ids) == ndraws_new
+            @test r2.psis_result isa PSIS.PSISResult
+            # new draws are NOT necessarily in the original pool
+        end
+
+        @testset "generate new draws without importance" begin
+            r2 = resample(result, ndraws_new; ndraws_per_run=50, importance=false, replace=true)
+            @test size(r2.draws) == (dim, ndraws_new)
+            @test r2.psis_result === nothing
+        end
+
+        @testset "non-mutating: original result unchanged" begin
+            draws_before = copy(result.draws)
+            resample(result, ndraws_new)
+            @test result.draws == draws_before
+        end
+
+        @testset "preserved fields" begin
+            r2 = resample(result, ndraws_new)
+            @test r2.input === result.input
+            @test r2.optimizer === result.optimizer
+            @test r2.fit_distribution === result.fit_distribution
+            @test r2.fit_distribution_transformed === result.fit_distribution_transformed
+            @test r2.pathfinder_results === result.pathfinder_results
+            @test r2.logp === result.logp
+        end
+    end
 end

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -10,10 +10,23 @@ using Test
     xsub = Pathfinder.resample(rng, x, 500)
     @test all(in.(xsub, Ref(x)))
 
+    @testset "replace=false" begin
+        xsub = Pathfinder.resample(rng, x, 10; replace=false)
+        @test all(in.(xsub, Ref(x)))
+        @test length(unique(xsub)) == 10
+    end
+
     # weight the first 20% much higher than the remaining 80%
     log_weights = randn(100)
     log_weights[1:20] .+= 1_000
     xsub, result = Pathfinder.resample(rng, x, log_weights, 500)
     @test all(in.(xsub, Ref(x[1:20])))
     @test result isa PSIS.PSISResult
+
+    @testset "replace=false with log_weights" begin
+        xsub, result = Pathfinder.resample(rng, x, log_weights, 10; replace=false)
+        @test all(in.(xsub, Ref(x[1:20])))
+        @test result isa PSIS.PSISResult
+        @test length(unique(xsub)) == 10
+    end
 end

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -3,15 +3,16 @@ using PSIS
 using Random
 using Test
 
-@testset "resample" begin
+@testset "_resample" begin
     x = randn(100)
 
     rng = Random.seed!(Random.default_rng(), 42)
-    xsub = Pathfinder.resample(rng, x, 500)
+    xsub, nothing_result = Pathfinder._resample(rng, x, nothing, 500)
     @test all(in.(xsub, Ref(x)))
+    @test nothing_result === nothing
 
     @testset "replace=false" begin
-        xsub = Pathfinder.resample(rng, x, 10; replace=false)
+        xsub, _ = Pathfinder._resample(rng, x, nothing, 10; replace=false)
         @test all(in.(xsub, Ref(x)))
         @test length(unique(xsub)) == 10
     end
@@ -19,14 +20,22 @@ using Test
     # weight the first 20% much higher than the remaining 80%
     log_weights = randn(100)
     log_weights[1:20] .+= 1_000
-    xsub, result = Pathfinder.resample(rng, x, log_weights, 500)
+    xsub, psis_result = Pathfinder._resample(rng, x, log_weights, 500)
     @test all(in.(xsub, Ref(x[1:20])))
-    @test result isa PSIS.PSISResult
+    @test psis_result isa PSIS.PSISResult
 
     @testset "replace=false with log_weights" begin
-        xsub, result = Pathfinder.resample(rng, x, log_weights, 10; replace=false)
+        xsub, psis_result = Pathfinder._resample(rng, x, log_weights, 10; replace=false)
         @test all(in.(xsub, Ref(x[1:20])))
-        @test result isa PSIS.PSISResult
+        @test psis_result isa PSIS.PSISResult
+        @test length(unique(xsub)) == 10
+    end
+
+    @testset "from PSISResult" begin
+        _, stored_psis = Pathfinder._resample(rng, x, log_weights, 500)
+        xsub, psis_result = Pathfinder._resample(rng, x, stored_psis, 10; replace=false)
+        @test all(in.(xsub, Ref(x[1:20])))
+        @test psis_result === stored_psis
         @test length(unique(xsub)) == 10
     end
 end

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -1,41 +1,133 @@
+using Distributions
+using LinearAlgebra
 using Pathfinder
 using PSIS
 using Random
 using Test
 
 @testset "_resample" begin
-    x = randn(100)
+    dim = 3
+    ndraws_per_component = 10
+    ncomponents = 4
+    ndraws = 20
+    rng = Xoshiro(42)
+    draws_per_component = randn(rng, dim, ndraws_per_component, ncomponents)
+    draws_all = reshape(draws_per_component, dim, :)
 
-    rng = Random.seed!(Random.default_rng(), 42)
-    xsub, nothing_result = Pathfinder._resample(rng, x, nothing, 500)
-    @test all(in.(xsub, Ref(x)))
-    @test nothing_result === nothing
-
-    @testset "replace=false" begin
-        xsub, _ = Pathfinder._resample(rng, x, nothing, 10; replace=false)
-        @test all(in.(xsub, Ref(x)))
-        @test length(unique(xsub)) == 10
+    @testset "uniform sampling (nothing)" begin
+        draws, component_ids = Pathfinder._resample(rng, draws_per_component, nothing, ndraws)
+        @test draws isa AbstractMatrix
+        @test size(draws) == (dim, ndraws)
+        @test component_ids isa AbstractVector{Int}
+        @test length(component_ids) == ndraws
+        @test all(1 .≤ component_ids .≤ ncomponents)
+        for col in eachcol(draws)
+            @test any(==(col), eachcol(draws_all))
+        end
     end
 
-    # weight the first 20% much higher than the remaining 80%
-    log_weights = randn(100)
-    log_weights[1:20] .+= 1_000
-    xsub, psis_result = Pathfinder._resample(rng, x, log_weights, 500)
-    @test all(in.(xsub, Ref(x[1:20])))
+    @testset "without replacement" begin
+        draws, _ = Pathfinder._resample(rng, draws_per_component, nothing, 5; replace=false)
+        @test length(unique(eachcol(draws))) == 5
+    end
+
+    @testset "weighted sampling (PSISResult)" begin
+        # weight only the first component
+        log_weights = fill(-1_000.0, ndraws_per_component, ncomponents)
+        log_weights[:, 1] .= 0.0
+        psis_result = PSIS.psis(vec(log_weights))
+        draws, component_ids = Pathfinder._resample(rng, draws_per_component, psis_result, ndraws)
+        @test size(draws) == (dim, ndraws)
+        @test all(==(1), component_ids)
+        for col in eachcol(draws)
+            @test any(==(col), eachcol(draws_per_component[:, :, 1]))
+        end
+    end
+
+    @testset "component_ids consistent with draws" begin
+        draws, component_ids = Pathfinder._resample(rng, draws_per_component, nothing, ndraws)
+        for (draw, cid) in zip(eachcol(draws), component_ids)
+            @test 1 ≤ cid ≤ ncomponents
+            @test any(==(draw), eachcol(draws_per_component[:, :, cid]))
+        end
+    end
+end
+
+@testset "_compute_log_importance_ratios" begin
+    dim = 2
+    ndraws_per_component = 5
+    ncomponents = 3
+    rng = Xoshiro(7)
+
+    μs = [fill(float(k), dim) for k in 1:ncomponents]
+    components = [MvNormal(μ, I(dim)) for μ in μs]
+    draws_per_component = stack(map(c -> rand(rng, c, ndraws_per_component), components))
+
+    target = MvNormal(zeros(dim), I(dim))
+    logp(x) = logpdf(target, x)
+
+    log_ratios = Pathfinder._compute_log_importance_ratios(logp, components, draws_per_component, 1)
+    @test log_ratios isa AbstractVector{<:Real}
+    @test length(log_ratios) == ndraws_per_component * ncomponents
+
+    # Each draw x at position (j, k) should satisfy: ratio = logp(x) - logpdf(components[k], x).
+    # vec iterates column-major: (j=1,k=1), …, (j=N,k=1), (j=1,k=2), …
+    expected = vec([
+        logp(draws_per_component[:, j, k]) - logpdf(components[k], draws_per_component[:, j, k])
+        for j in 1:ndraws_per_component, k in 1:ncomponents
+    ])
+    @test log_ratios ≈ expected
+end
+
+@testset "_compute_psis_result" begin
+    dim = 2
+    ndraws_per_component = 20
+    ncomponents = 3
+    rng = Xoshiro(11)
+
+    components = [MvNormal(fill(float(k), dim), I(dim)) for k in 1:ncomponents]
+    draws_per_component = stack(map(c -> rand(rng, c, ndraws_per_component), components))
+
+    target = MvNormal(zeros(dim), I(dim))
+    logp(x) = logpdf(target, x)
+
+    psis_result = Pathfinder._compute_psis_result(logp, components, draws_per_component; ntasks=1)
     @test psis_result isa PSIS.PSISResult
+    @test length(psis_result.weights) == ndraws_per_component * ncomponents
+    @test sum(psis_result.weights) ≈ 1
+end
 
-    @testset "replace=false with log_weights" begin
-        xsub, psis_result = Pathfinder._resample(rng, x, log_weights, 10; replace=false)
-        @test all(in.(xsub, Ref(x[1:20])))
-        @test psis_result isa PSIS.PSISResult
-        @test length(unique(xsub)) == 10
+@testset "_candidate_draws_and_psis_result" begin
+    dim = 3
+    ndraws_per_component = 8
+    nruns = 3
+    logp(x) = -sum(abs2, x) / 2
+    ℓ = build_logdensityproblem(logp, dim, 2)
+    rng = Xoshiro(99)
+
+    result_with_psis = multipathfinder(ℓ, ndraws_per_component; nruns, ndraws_per_run=ndraws_per_component, rng)
+    result_no_psis = multipathfinder(ℓ, ndraws_per_component; nruns, ndraws_per_run=ndraws_per_component, rng, importance=false)
+    @test result_with_psis.psis_result isa PSIS.PSISResult
+    @test result_no_psis.psis_result === nothing
+
+    @testset "::Nothing reuses stored draws" begin
+        draws, psis = Pathfinder._candidate_draws_and_psis_result(rng, result_with_psis, nothing)
+        @test size(draws) == (dim, ndraws_per_component, nruns)
+        @test psis === result_with_psis.psis_result
+        expected = stack(map(r -> r.draws, result_with_psis.pathfinder_results))
+        @test draws == expected
     end
 
-    @testset "from PSISResult" begin
-        _, stored_psis = Pathfinder._resample(rng, x, log_weights, 500)
-        xsub, psis_result = Pathfinder._resample(rng, x, stored_psis, 10; replace=false)
-        @test all(in.(xsub, Ref(x[1:20])))
-        @test psis_result === stored_psis
-        @test length(unique(xsub)) == 10
+    @testset "::Nothing with no stored PSIS returns nothing" begin
+        draws, psis = Pathfinder._candidate_draws_and_psis_result(rng, result_no_psis, nothing)
+        @test size(draws) == (dim, ndraws_per_component, nruns)
+        @test psis === nothing
+    end
+
+    @testset "::Int generates fresh draws" begin
+        ndraws_new = 15
+        draws, psis = Pathfinder._candidate_draws_and_psis_result(rng, result_with_psis, ndraws_new)
+        @test size(draws) == (dim, ndraws_new, nruns)
+        @test psis === nothing
     end
 end

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -15,7 +15,9 @@ using Test
     draws_all = reshape(draws_per_component, dim, :)
 
     @testset "uniform sampling (nothing)" begin
-        draws, component_ids = Pathfinder._resample(rng, draws_per_component, nothing, ndraws)
+        draws, component_ids = Pathfinder._resample(
+            rng, draws_per_component, nothing, ndraws
+        )
         @test draws isa AbstractMatrix
         @test size(draws) == (dim, ndraws)
         @test component_ids isa AbstractVector{Int}
@@ -36,7 +38,9 @@ using Test
         log_weights = fill(-1_000.0, ndraws_per_component, ncomponents)
         log_weights[:, 1] .= 0.0
         psis_result = PSIS.psis(vec(log_weights))
-        draws, component_ids = Pathfinder._resample(rng, draws_per_component, psis_result, ndraws)
+        draws, component_ids = Pathfinder._resample(
+            rng, draws_per_component, psis_result, ndraws
+        )
         @test size(draws) == (dim, ndraws)
         @test all(==(1), component_ids)
         for col in eachcol(draws)
@@ -45,7 +49,9 @@ using Test
     end
 
     @testset "component_ids consistent with draws" begin
-        draws, component_ids = Pathfinder._resample(rng, draws_per_component, nothing, ndraws)
+        draws, component_ids = Pathfinder._resample(
+            rng, draws_per_component, nothing, ndraws
+        )
         for (draw, cid) in zip(eachcol(draws), component_ids)
             @test 1 ≤ cid ≤ ncomponents
             @test any(==(draw), eachcol(draws_per_component[:, :, cid]))
@@ -66,15 +72,18 @@ end
     target = MvNormal(zeros(dim), I(dim))
     logp(x) = logpdf(target, x)
 
-    log_ratios = Pathfinder._compute_log_importance_ratios(logp, components, draws_per_component, 1)
+    log_ratios = Pathfinder._compute_log_importance_ratios(
+        logp, components, draws_per_component, 1
+    )
     @test log_ratios isa AbstractVector{<:Real}
     @test length(log_ratios) == ndraws_per_component * ncomponents
 
     # Each draw x at position (j, k) should satisfy: ratio = logp(x) - logpdf(components[k], x).
     # vec iterates column-major: (j=1,k=1), …, (j=N,k=1), (j=1,k=2), …
     expected = vec([
-        logp(draws_per_component[:, j, k]) - logpdf(components[k], draws_per_component[:, j, k])
-        for j in 1:ndraws_per_component, k in 1:ncomponents
+        logp(draws_per_component[:, j, k]) -
+        logpdf(components[k], draws_per_component[:, j, k]) for
+        j in 1:ndraws_per_component, k in 1:ncomponents
     ])
     @test log_ratios ≈ expected
 end
@@ -91,7 +100,9 @@ end
     target = MvNormal(zeros(dim), I(dim))
     logp(x) = logpdf(target, x)
 
-    psis_result = Pathfinder._compute_psis_result(logp, components, draws_per_component; ntasks=1)
+    psis_result = Pathfinder._compute_psis_result(
+        logp, components, draws_per_component; ntasks=1
+    )
     @test psis_result isa PSIS.PSISResult
     @test length(psis_result.weights) == ndraws_per_component * ncomponents
     @test sum(psis_result.weights) ≈ 1
@@ -105,13 +116,24 @@ end
     ℓ = build_logdensityproblem(logp, dim, 2)
     rng = Xoshiro(99)
 
-    result_with_psis = multipathfinder(ℓ, ndraws_per_component; nruns, ndraws_per_run=ndraws_per_component, rng)
-    result_no_psis = multipathfinder(ℓ, ndraws_per_component; nruns, ndraws_per_run=ndraws_per_component, rng, importance=false)
+    result_with_psis = multipathfinder(
+        ℓ, ndraws_per_component; nruns, ndraws_per_run=ndraws_per_component, rng
+    )
+    result_no_psis = multipathfinder(
+        ℓ,
+        ndraws_per_component;
+        nruns,
+        ndraws_per_run=ndraws_per_component,
+        rng,
+        importance=false,
+    )
     @test result_with_psis.psis_result isa PSIS.PSISResult
     @test result_no_psis.psis_result === nothing
 
     @testset "::Nothing reuses stored draws" begin
-        draws, psis = Pathfinder._candidate_draws_and_psis_result(rng, result_with_psis, nothing)
+        draws, psis = Pathfinder._candidate_draws_and_psis_result(
+            rng, result_with_psis, nothing
+        )
         @test size(draws) == (dim, ndraws_per_component, nruns)
         @test psis === result_with_psis.psis_result
         expected = stack(map(r -> r.draws, result_with_psis.pathfinder_results))
@@ -119,14 +141,18 @@ end
     end
 
     @testset "::Nothing with no stored PSIS returns nothing" begin
-        draws, psis = Pathfinder._candidate_draws_and_psis_result(rng, result_no_psis, nothing)
+        draws, psis = Pathfinder._candidate_draws_and_psis_result(
+            rng, result_no_psis, nothing
+        )
         @test size(draws) == (dim, ndraws_per_component, nruns)
         @test psis === nothing
     end
 
     @testset "::Int generates fresh draws" begin
         ndraws_new = 15
-        draws, psis = Pathfinder._candidate_draws_and_psis_result(rng, result_with_psis, ndraws_new)
+        draws, psis = Pathfinder._candidate_draws_and_psis_result(
+            rng, result_with_psis, ndraws_new
+        )
         @test size(draws) == (dim, ndraws_new, nruns)
         @test psis === nothing
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -25,18 +25,18 @@ using Test
     @testset "_maybe_tmap" begin
         xs = randn(50)
         @testset "ntasks=$ntasks" for ntasks in (1, Threads.nthreads())
-            @test Pathfinder._maybe_tmap(sin, xs, ntasks) == map(sin, xs)
-            @test Pathfinder._maybe_tmap(sin, Float64[], ntasks) == Float64[]
+            @test Pathfinder._maybe_tmap(sin, xs; ntasks) == map(sin, xs)
+            @test Pathfinder._maybe_tmap(sin, Float64[]; ntasks) == Float64[]
         end
     end
 
     @testset "_maybe_tmapreduce" begin
         xs = [randn(3) for _ in 1:20]
         @testset "ntasks=$ntasks" for ntasks in (1, Threads.nthreads())
-            @test Pathfinder._maybe_tmapreduce(identity, vcat, xs, ntasks) ==
+            @test Pathfinder._maybe_tmapreduce(identity, vcat, xs; ntasks) ==
                 mapreduce(identity, vcat, xs)
             # `+` on floats is non-associative, so parallel reduction order may differ
-            @test Pathfinder._maybe_tmapreduce(sum, +, xs, ntasks) ≈ mapreduce(sum, +, xs)
+            @test Pathfinder._maybe_tmapreduce(sum, +, xs; ntasks) ≈ mapreduce(sum, +, xs)
         end
     end
 
@@ -53,9 +53,11 @@ using Test
                 return s * x
             end == map(x -> 10x, xs)
             # empty arrays return empty
-            @test isempty(Pathfinder._chunk_tmap(Int[]; ntasks, setup=() -> 0) do _, x
-                return x
-            end)
+            @test isempty(
+                Pathfinder._chunk_tmap(Int[]; ntasks, setup=() -> 0) do _, x
+                    return x
+                end,
+            )
         end
 
         # the reproducible-seeding idiom yields identical output regardless of ntasks
@@ -63,7 +65,9 @@ using Test
             rng = Random.seed!(Random.default_rng(), seed)
             xs = collect(1:n)
             seeds = rand!(rng, similar(xs, UInt64))
-            return Pathfinder._chunk_tmap(xs, seeds; ntasks, setup=() -> copy(rng)) do r, _, s
+            return Pathfinder._chunk_tmap(
+                xs, seeds; ntasks, setup=() -> copy(rng)
+            ) do r, _, s
                 Random.seed!(r, s)
                 return rand(r)
             end


### PR DESCRIPTION
Adds a public `resample(result::MultiPathfinderResult, ndraws; kwargs...)` function for post-hoc resampling from a fitted Pathfinder result, without re-running the optimization.

Motivated by [this case study](https://users.aalto.fi/~ave/casestudies/Birthdays/birthdays.html) on PSIS-weighted importance sampling without replacement as a diagnostic tool and for seeding MCMC chains when Pareto-k is bad.

🤖 Co-authored with [Claude Code](https://claude.ai/code)

## What this does

Two workflows are now supported without re-running Pathfinder:

**Workflow 1 — bad Pareto-k, seed MCMC chains with unique draws:**
```julia
result = multipathfinder(model, 400; nruns=8)
result.psis_result.pareto_shape  # e.g. 0.85 → bad

init = resample(result, 8; replace=false)  # 8 unique PSIS-weighted draws, zero logp re-evals
```

**Workflow 2 — too few draws, generate more from fitted approximation:**
```julia
result = multipathfinder(model, 50; nruns=8, ndraws_per_run=10)
big = resample(result, 500; ndraws_per_run=100, replace=true)
```

## Checklist

- [x] `replace` kwarg added to internal `resample(rng, x, ...)` (default `true`, no breaking change)
- [x] `_get_candidate_draws` — uses existing draws or generates fresh ones from `fit_distribution`
- [x] `_compute_log_densities_ratios` — evaluates logp for fresh draws when `importance=true`
- [x] `_rebuild_draws_transformed` — extension hook; Turing override reconstructs correct chain type
- [x] `_build_resampled_result` — constructs new `MultiPathfinderResult` with updated fields
- [x] `resample(::MultiPathfinderResult)` exported as public API
- [x] Tests for all four combinations of existing/fresh draws × importance on/off
- [x] Docs: usage guide section with case study example