### PR TITLE
ci: standardize Downgrade workflow

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -19,20 +19,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: ['1.11']
+        version: ['lts']
         os: ['ubuntu-latest']
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
-        id: setup-julia
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/julia-downgrade-compat@v2
         with:
-          julia_version: ${{ matrix.version }}
-          skip: LinearAlgebra,Random,Statistics
+          mode: deps
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
           allow_reresolve: false
           force_latest_compatible_version: false
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- Track Julia \`lts\` instead of a hardcoded version
- Drop \`skip\`/\`julia_version\` inputs in favor of an explicit \`mode: deps\`
- Add coverage reporting to match the rest of the fleet